### PR TITLE
Implement minimal BOM generation from Gradle.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,11 @@
             <version>${gradle.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.0.5</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -18,23 +18,31 @@
 package org.cyclonedx.gradle;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.maven.project.MavenProject;
 import org.cyclonedx.BomGenerator;
 import org.cyclonedx.BomParser;
 import org.cyclonedx.model.Component;
+import org.cyclonedx.model.License;
+import org.cyclonedx.util.BomUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
+import org.gradle.api.artifacts.ModuleVersionIdentifier;
+import org.gradle.api.artifacts.ResolveException;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedModuleVersion;
 import org.gradle.api.tasks.TaskAction;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
 import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -58,50 +66,131 @@ public class CycloneDxTask extends DefaultTask {
         this.buildDir = buildDir;
     }
 
-    /**
-     * This code does not currently work. TESTING ONLY
-     */
     @TaskAction
     public void createBom() {
+
+        Set<String> builtDependencies = getProject()
+            .getRootProject()
+            .getSubprojects()
+            .stream()
+            .map(p -> p.getGroup() + ":" + p.getName() + ":" + p.getVersion())
+            .collect(Collectors.toSet());
+
         Set<Component> components = new LinkedHashSet<>();
-        getLogger().info("PROJECT NAME" + getProject().getName());
         for (Project p : getProject().getAllprojects()) {
-            getLogger().info("ALL-PROJECT NAME" + p.getName());
             for (Configuration configuration : p.getConfigurations()) {
                 if (!shouldSkipConfiguration(configuration)) {
                     ResolvedConfiguration resolvedConfiguration = configuration.getResolvedConfiguration();
                     if (resolvedConfiguration != null) {
                         for (ResolvedArtifact artifact : resolvedConfiguration.getResolvedArtifacts()) {
-                            getLogger().info("RESOLVED ARTIFACt: " + artifact.getName());
-                            getLogger().info("TYPE: " + artifact.getType());
-                            getLogger().info("CLASSIFIER: " + artifact.getClassifier());
-                            getLogger().info("GROUP: " + artifact.getModuleVersion().getId().getGroup());
+                            getLogger().debug("RESOLVED ARTIFACT: " + artifact.getName());
+                            getLogger().debug("TYPE: " + artifact.getType());
+                            getLogger().debug("CLASSIFIER: " + artifact.getClassifier());
+                            getLogger().debug("GROUP: " + artifact.getModuleVersion().getId().getGroup());
+
+                            // Don't include other resources built from this Gradle project.
+                            String dependencyName = getDependencyName(artifact);
+                            if(builtDependencies.stream().anyMatch(c -> c.equals(dependencyName))) {
+                                continue;
+                            }
+
+                            // Convert into a Component and augment with pom metadata if available.
+                            Component component = convertArtifact(artifact);
+                            augmentComponentMetadata(component, dependencyName);
+                            components.add(component);
                         }
                     }
                 }
-                DependencySet ds = configuration.getAllDependencies();
-                for (Dependency dependency : ds) {
-                    getLogger().info(dependency.getGroup() + ":" + dependency.getName() + ":" + dependency.getVersion());
+            }
+        }
+        writeBom(components);
+    }
+
+    public String getDependencyName(ResolvedArtifact artifact) {
+        ModuleVersionIdentifier m = artifact.getModuleVersion().getId();
+        return m.getGroup() + ":" + m.getName() + ":" + m.getVersion();
+    }
+
+    public void augmentComponentMetadata(Component component, String dependencyName) {
+        Dependency pomDep = getProject()
+            .getDependencies()
+            .create(dependencyName + "@pom");
+        Configuration pomCfg = getProject()
+            .getConfigurations()
+            .detachedConfiguration(pomDep);
+        MavenProject project = null;
+
+        try {
+            File pomFile = pomCfg.resolve().stream().findFirst().orElse(null);
+            project = MavenUtils.readPom(pomFile);
+        } catch(IOException err) {
+            getLogger().error("Unable to resolve POM for " + component + ": " + err);
+        } catch(ResolveException err) {
+            getLogger().error("Unable to resolve POM for " + component + ": " + err);
+        }
+
+        if(project != null) {
+            if(project.getOrganization() != null) {
+                component.setPublisher(project.getOrganization().getName());
+            }
+            component.setDescription(project.getDescription());
+            if(project.getLicenses() != null) {
+                final List<License> licenses = new ArrayList<>();
+                for(org.apache.maven.model.License artifactLicense : project.getLicenses()) {
+                    License license = new License();
+                    if(artifactLicense.getName() != null) {
+                        license.setName(artifactLicense.getName());
+                        licenses.add(license);
+                    } else if(artifactLicense.getUrl() != null) {
+                        license.setName(artifactLicense.getUrl());
+                        licenses.add(license);
+                    }
+                }
+                if(licenses.size() > 0) {
+                    component.setLicenses(licenses);
                 }
             }
         }
     }
 
+    public Component convertArtifact(ResolvedArtifact artifact) {
+        final Component component = new Component();
+        component.setGroup(artifact.getModuleVersion().getId().getGroup());
+        component.setName(artifact.getModuleVersion().getId().getName());
+        component.setVersion(artifact.getModuleVersion().getId().getVersion());
+        component.setType("library");
+        try {
+            getLogger().debug(MESSAGE_CALCULATING_HASHES);
+            component.setHashes(BomUtils.calculateHashes(artifact.getFile()));
+        } catch(IOException e) {
+            getLogger().error("Error encountered calculating hashes", e);
+        }
+
+        return component;
+    }
+
+
     private boolean shouldSkipConfiguration(Configuration configuration) {
-        final List<String> skipConfigs = Arrays.asList("apiElements", "implementation", "runtimeElements", "runtimeOnly", "testImplementation", "testRuntimeOnly");
+        final List<String> skipConfigs = Arrays.asList(
+                "apiElements",
+                "implementation",
+                "runtimeElements",
+                "runtimeOnly",
+                "testImplementation",
+                "testRuntimeOnly");
         return skipConfigs.contains(configuration.getName());
     }
 
     /**
      * Ported from Maven plugin.
      */
-    protected void execute(Set<Component> components) throws GradleException{
+    protected void writeBom(Set<Component> components) throws GradleException{
         try {
             getLogger().info(MESSAGE_CREATING_BOM);
             final BomGenerator bomGenerator = new BomGenerator(components);
             bomGenerator.generate();
             final String bomString = bomGenerator.toXmlString();
-            final File bomFile = new File(buildDir, "target/bom.xml");
+            final File bomFile = new File(buildDir, "reports/bom.xml");
             getLogger().info(MESSAGE_WRITING_BOM);
             FileUtils.write(bomFile, bomString, Charset.forName("UTF-8"), false);
             getLogger().info(MESSAGE_VALIDATING_BOM);

--- a/src/main/java/org/cyclonedx/gradle/MavenUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/MavenUtils.java
@@ -1,0 +1,49 @@
+package org.cyclonedx.gradle;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.apache.maven.model.Model;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.gradle.api.artifacts.ResolvedArtifact;
+
+
+public class MavenUtils {
+
+    /**
+     * Reads a POM and creates a MavenProject from it.
+     * @param file the file object of the POM to read
+     * @return a MavenProject
+     * @throws IOException oops
+     */
+    public static MavenProject readPom(File file) throws IOException {
+        try (final FileInputStream in = new FileInputStream(file)) {
+            return readPom(in);
+        }
+    }
+
+    /**
+     * Reads a POM and creates a MavenProject from it.
+     * @param in the inputstream to read from
+     * @return a MavenProject
+     */
+    public static MavenProject readPom(InputStream in) {
+        try {
+            final MavenXpp3Reader mavenreader = new MavenXpp3Reader();
+            try (final InputStreamReader reader = new InputStreamReader(in)) {
+                final Model model = mavenreader.read(reader);
+                return new MavenProject(model);
+            }
+        } catch (XmlPullParserException | IOException e) {
+            //getLogger().error("An error occurred attempting to read POM", e);
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
Hi, I've taken a shot at completing out the implementation of BOM generation for Gradle.  I'm not terribly familiar with the Gradle APIs and there may be more effective ways of doing this work, but this PR appears to be functional.

There are a few changes compared to the original approach including:

**Generating a list of sub projects**
This code generates a list of sub projects which are built as dependencies and filters them out.  In my very limited Gradle experience these tend to be part of the same code base and thus not an external dependency that you would want to track.

**Resolve POM metadata**
In order to pull out the license and organizational details from the dependencies the plugin now asks Gradle to fetch the POM associated with each dependency and then parses it in order to extract these details.  If this operation fails the plugin continues without annotating the extra details.

This is using the Maven libraries to parse the POM files with code borrowed from the Maven plugin.  If this dependency is undesired we can probably drop it and parse the POM XML files directly.

The approach of fetching the POM metadata is inspired by one of the [gradle license plugins](https://github.com/hierynomus/license-gradle-plugin).

----

I would love to not have to maintain a vendored copy of these library so please let me know how I can help get this merged in and built.  

Thanks!