### PR TITLE
Issue10: Resolving configuration 'generatedImplementation' directly is not allowed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target/
+/.idea/
+/*.iml


### PR DESCRIPTION
Since Gradle 3.3 the Configuration class was extended by the information whether it can be resolved: [Configuration.isCanBeResolved()](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html#isCanBeResolved--)

This fix only considers resolvable configuration. This is done in a backwards-compatible way:
- Gradle 3.3 and up: rely on `Configuration.isCanBeResolved()`
- <3.3: configurations are always resolvable

I also removed the default values from the `skipConfigs` property which contained non-resolvable configurations.

This fix is basically a Java port of the [fix](https://github.com/jeremylong/dependency-check-gradle/pull/33) I provided for dependency-check-gradle.