### PR TITLE
README: Simplify instructions to apply the plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gradle cyclonedxBom -Pcyclonedx.includeBomSerialNumber=false
 __build.gradle__ (excerpt)
 ```groovy
 plugins {
-    id 'org.cyclonedx.bom' version '1.1.1' apply true
+    id 'org.cyclonedx.bom'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
"apply true" is the default anyway, and it is enough to mention the
version only once as part of the pluginManagement block.