### PR TITLE
CycloneDxPlugin: Set a group for the task to make it visible

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
@@ -24,6 +24,7 @@ public class CycloneDxPlugin implements Plugin<Project> {
 
     public void apply(Project project) {
         project.getTasks().create("cyclonedxBom", CycloneDxTask.class, (task) -> {
+            task.setGroup("Reporting");
             task.setBuildDir(project.getBuildDir());
         });
     }


### PR DESCRIPTION
This makes the task show up in "./gradlew tasks". Previously "./gradlew
tasks --all" was needed.

Fixes #14.