### PR TITLE
Make the POM error more useful by emitting the purl.

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -183,9 +183,9 @@ public class CycloneDxTask extends DefaultTask {
             final File pomFile = pomCfg.resolve().stream().findFirst().orElse(null);
             project = mavenHelper.readPom(pomFile);
         } catch(IOException err) {
-            getLogger().error("Unable to resolve POM for " + component + ": " + err);
+            getLogger().error("Unable to resolve POM for " + component.getPurl() + ": " + err);
         } catch(ResolveException err) {
-            getLogger().error("Unable to resolve POM for " + component + ": " + err);
+            getLogger().error("Unable to resolve POM for " + component.getPurl() + ": " + err);
         }
 
         if(project != null) {
@@ -264,6 +264,7 @@ public class CycloneDxTask extends DefaultTask {
 
     /**
      * Ported from Maven plugin.
+     * @param components The CycloneDX components extracted from gradle dependencies
      */
     protected void writeBom(Set<Component> components) throws GradleException{
         try {


### PR DESCRIPTION
Currently it just emits the class object reference, which is useless
when trying to track down which POM is missing.