### PR TITLE
Resolution performance improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 }
 
 group = 'com.cyclonedx'
-version = '1.1.3-SNAPSHOT'
+version = '1.1.4-SNAPSHOT'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -124,7 +124,7 @@ public class CycloneDxTask extends DefaultTask {
                 .map(p -> p.getGroup() + ":" + p.getName() + ":" + p.getVersion())
                 .collect(Collectors.toSet());
 
-        final Set<Component> components = getProject().getAllprojects().parallelStream()
+        final Set<Component> components = getProject().getAllprojects().stream()
             .flatMap(p -> p.getConfigurations().stream())
             .filter(configuration -> !shouldSkipConfiguration(configuration) && canBeResolved(configuration))
             .flatMap(configuration -> {

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -122,7 +122,7 @@ public class CycloneDxTask extends DefaultTask {
                 .map(p -> p.getGroup() + ":" + p.getName() + ":" + p.getVersion())
                 .collect(Collectors.toSet());
 
-        final Set<Component> components = getProject().getAllprojects().stream()
+        final Set<Component> components = getProject().getAllprojects().parallelStream()
             .flatMap(p -> p.getConfigurations().stream())
             .filter(configuration -> !shouldSkipConfiguration(configuration) && canBeResolved(configuration))
             .flatMap(configuration -> {

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -201,7 +201,10 @@ public class CycloneDxTask extends DefaultTask {
     private void augmentComponentMetadata(Component component, String dependencyName) {
         MavenProject project = null;
         try {
-            project = mavenHelper.readPom(getResolvedPom(dependencyName));
+            final File pomFile = getResolvedPom(dependencyName);
+            if(pomFile != null) {
+                project = mavenHelper.readPom(pomFile);
+            }
         } catch(IOException err) {
             getLogger().error("Unable to resolve POM for " + dependencyName + ": " + err);
         }


### PR DESCRIPTION
Cache the maven project models and the artifact file hashes, so they don't get reevaluated for the same artifacts.  A given artifact may be a dependency of multiple configurations in multiple subprojects.  For the same artifact, the maven model and the files hashes aren't going to change though!

Parallelize the resolution of POMs for additional metadata.  The detached configurations for these are generated on the fly, and don't have any dependencies between each other.  Gradle will happily resolve them in parallel.

These changes yield an order of magnitude improvement in runtime on my large, multiproject build.