### PR TITLE
Avoid fetching the same dependency twice

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -111,7 +111,7 @@ public class CycloneDxTask extends DefaultTask {
         }
         logParameters();
         getLogger().info(MESSAGE_RESOLVING_DEPS);
-        final Set<String> builtDependencies = getProject()
+        final Set<String> analysedDependencies = getProject()
                 .getRootProject()
                 .getSubprojects()
                 .stream()
@@ -128,9 +128,10 @@ public class CycloneDxTask extends DefaultTask {
                         for (final ResolvedArtifact artifact : resolvedConfiguration.getResolvedArtifacts()) {
                             // Don't include other resources built from this Gradle project.
                             final String dependencyName = getDependencyName(artifact);
-                            if(builtDependencies.stream().anyMatch(c -> c.equals(dependencyName))) {
+                            if(analysedDependencies.contains(dependencyName)) {
                                 continue;
                             }
+                            analysedDependencies.add(dependencyName);
 
                             depsFromConfig.add(dependencyName);
 


### PR DESCRIPTION
Fetching the information from the pom.xml can took some time. 
Already analysed dependencies are saved. If the same dependency needs
to be analysed again, it's skipped.

In our project, `./gradlew cyclonedxBom` goes from 12 minutes to 2 minutes with this fix.