### PR TITLE
Fix this so it will work in android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
 repositories {
     jcenter()
     mavenCentral()
+    mavenLocal()
     maven {
         url 'https://jitpack.io'
     }
@@ -23,8 +24,8 @@ dependencies {
     compile 'org.apache.maven:maven-core:3.5.0'
 }
 
-group = 'com.cyclonedx'
-version = '1.2.0-SNAPSHOT'
+group = 'org.cyclonedx'
+version = '1.2.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'org.cyclonedx', name: 'cyclonedx-core-java', version: '3.0.1') {
+    compile(group: 'org.cyclonedx', name: 'cyclonedx-core-java', version: '3.0.5') {
         // gradle-api already includes an slf4j binding
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
@@ -24,7 +24,7 @@ dependencies {
     compile 'org.apache.maven:maven-core:3.5.0'
 }
 
-group = 'org.cyclonedx'
+group = 'com.cyclonedx'
 version = '1.2.0'
 
 sourceCompatibility = JavaVersion.VERSION_1_8
@@ -43,7 +43,7 @@ pluginBundle {
 gradlePlugin {
     plugins {
         cycloneDxPlugin {
-            id = 'org.cyclonedx.bom'
+            id = 'com.cyclonedx.bom'
             displayName = 'CycloneDX BOM Generator'
             description = 'The CycloneDX Gradle plugin creates an aggregate of all direct and transitive dependencies of a project and creates a valid CycloneDX bill-of-materials document from the results. CycloneDX is a lightweight BOM specification that is easily created, human readable, and simple to parse.'
             implementationClass = 'org.cyclonedx.gradle.CycloneDxPlugin'

--- a/build.gradle
+++ b/build.gradle
@@ -19,8 +19,8 @@ dependencies {
         // gradle-api already includes an slf4j binding
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
-    compile 'commons-codec:commons-codec:1.13'
-    compile 'commons-io:commons-io:2.6'
+    compile 'commons-codec:commons-codec:1.15'
+    compile 'commons-io:commons-io:2.7'
     compile 'org.apache.maven:maven-core:3.5.0'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
     id 'java-gradle-plugin'
-    id 'com.gradle.plugin-publish' version '0.10.1'
+    id 'com.gradle.plugin-publish' version '0.12.0'
     id 'maven-publish'
 }
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.cyclonedx</groupId>
     <artifactId>cyclonedx-gradle-plugin</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>1.2.0</version>
 
     <name>CycloneDX Gradle Plugin</name>
     <description>The CycloneDX Gradle plugin creates an aggregate of all direct and transitive dependencies of a project and creates a valid CycloneDX bill-of-materials document from the results. CycloneDX is a lightweight BOM specification that is easily created, human readable, and simple to parse.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.cyclonedx</groupId>
+    <groupId>com.cyclonedx</groupId>
     <artifactId>cyclonedx-gradle-plugin</artifactId>
     <packaging>jar</packaging>
     <version>1.2.0</version>

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -258,6 +258,7 @@ public class CycloneDxTask extends DefaultTask {
 
     private Component convertArtifact(ResolvedArtifact artifact) {
         final Component component = new Component();
+        getLogger().debug("convertArtifact: working on " + artifact.getModuleVersion().getId().getName());
         component.setGroup(artifact.getModuleVersion().getId().getGroup());
         component.setName(artifact.getModuleVersion().getId().getName());
         component.setVersion(artifact.getModuleVersion().getId().getVersion());

--- a/src/test/build.gradle
+++ b/src/test/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.cyclonedx.bom' version '1.1.0' apply true
+    id 'org.cyclonedx.bom' version '1.2.0' apply true
 }
 
 apply plugin: 'java'

--- a/src/test/settings.gradle
+++ b/src/test/settings.gradle
@@ -2,7 +2,7 @@ pluginManagement {
     resolutionStrategy {
         eachPlugin {
             if (requested.id.toString() == 'org.cyclonedx.bom') {
-                useModule('org.cyclonedx:cyclonedx-gradle-plugin:1.1.0')
+                useModule('org.cyclonedx:cyclonedx-gradle-plugin:1.2.0')
             }
         }
     }


### PR DESCRIPTION
Made some changes so it will build a release. Tested in one of our android projects. Results of applying:
```
> Task :cyclonedxBom
Task :cyclonedxBom in app Starting
Caching disabled for task ':cyclonedxBom' because:
  Caching has not been enabled for the task
Task ':cyclonedxBom' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
CycloneDX: Parameters
------------------------------------------------------------------------
schemaVersion          : VERSION_12
includeBomSerialNumber : true
------------------------------------------------------------------------
CycloneDX: Resolving Dependencies
BOM inclusion for configuration _classStructurekaptDebugAndroidTestKotlin : []
BOM inclusion for configuration _classStructurekaptDebugKotlin : []
BOM inclusion for configuration _classStructurekaptDebugUnitTestKotlin : []
BOM inclusion for configuration _classStructurekaptEspressoKotlin : []
BOM inclusion for configuration _classStructurekaptEspressoUnitTestKotlin : []
BOM inclusion for configuration _classStructurekaptReleaseKotlin : []
BOM inclusion for configuration _classStructurekaptReleaseUnitTestKotlin : []
BOM inclusion for configuration _internal_aapt2_binary : [com.android.tools.build:aapt2:4.0.0-6051327]
BOM inclusion for configuration androidApis : []
BOM inclusion for configuration androidTestApiDependenciesMetadata : []
BOM inclusion for configuration androidTestCompileOnlyDependenciesMetadata : []
BOM inclusion for configuration androidTestDebugApiDependenciesMetadata : []
BOM inclusion for configuration androidTestDebugCompileOnlyDependenciesMetadata : []
BOM inclusion for configuration androidTestDebugImplementationDependenciesMetadata : []
BOM inclusion for configuration androidTestDebugRuntimeOnlyDependenciesMetadata : []
BOM inclusion for configuration androidTestImplementationDependenciesMetadata : [androidx.annotation:annotation:1.0.0, androidx.lifecycle:lifecycle-common:2.0.0, androidx.test.espresso:espresso-core:3.2.0, androidx.test.espresso:espresso-idling-resource:3.2.0, androidx.test.ext:junit:1.1.1, androidx.test:core:1.2.0, androidx.test:monitor:1.2.0, androidx.test:runner:1.2.0, com.google.code.findbugs:jsr305:2.0.1, com.squareup:javawriter:2.1.1, javax.inject:javax.inject:1, junit:junit:4.12, net.sf.kxml:kxml2:2.3.0, org.hamcrest:hamcrest-core:1.3, org.hamcrest:hamcrest-integration:1.3, org.hamcrest:hamcrest-library:1.3]
BOM inclusion for configuration androidTestRuntimeOnlyDependenciesMetadata : []
BOM inclusion for configuration androidTestUtil : []
BOM inclusion for configuration apiDependenciesMetadata : [androidx.annotation:annotation:1.0.0, androidx.arch.core:core-common:2.0.0, androidx.collection:collection:1.0.0, androidx.databinding:databinding-adapters:4.0.0, androidx.databinding:databinding-common:4.0.0, androidx.databinding:databinding-runtime:4.0.0, androidx.databinding:viewbinding:4.0.0, androidx.lifecycle:lifecycle-common:2.0.0, androidx.lifecycle:lifecycle-runtime:2.0.0]
BOM inclusion for configuration archives : []
BOM inclusion for configuration compile : []
BOM inclusion for configuration compileOnlyDependenciesMetadata : []
BOM inclusion for configuration coreLibraryDesugaring : [com.android.tools:desugar_jdk_libs:1.0.9, com.android.tools:desugar_jdk_libs_configuration:1.0.9]
BOM inclusion for configuration debugAndroidTestAnnotationProcessorClasspath : []
BOM inclusion for configuration debugAndroidTestApiDependenciesMetadata : []
BOM inclusion for configuration debugAndroidTestCompile : []
:cyclonedxBom took 823ms
Task :cyclonedxBom in app Finished

> Task :cyclonedxBom FAILED
:cyclonedxBom (Thread[Execution worker for ':',5,main]) completed. Took 2.85 secs.

```

Still would like to understand `FAILED` after seeing no errors.