### PR TITLE
Document metadata parameter

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -318,6 +318,7 @@ public class CycloneDxTask extends DefaultTask {
 
     /**
      * Ported from Maven plugin.
+     * @param metadata The CycloneDX metadata object
      * @param components The CycloneDX components extracted from gradle dependencies
      */
     protected void writeBom(Metadata metadata, Set<Component> components) throws GradleException{


### PR DESCRIPTION
was causing a gradle build warning.