### PR TITLE
Create a copy of configuration to resolve before resolution

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -147,10 +147,12 @@ public class CycloneDxTask extends DefaultTask {
                 .collect(Collectors.toSet());
 
         final Metadata metadata = createMetadata();
-        final Set<Component> components = getProject().getAllprojects().stream()
-            .flatMap(p -> p.getConfigurations().stream())
-            .filter(configuration -> shouldIncludeConfiguration(configuration) && !shouldSkipConfiguration(configuration) && canBeResolved(configuration))
-            .flatMap(configuration -> {
+        final Set<Configuration> configurations = getProject().getAllprojects().stream()
+                .flatMap(p -> p.getConfigurations().stream())
+                .filter(configuration -> shouldIncludeConfiguration(configuration) && !shouldSkipConfiguration(configuration) && canBeResolved(configuration))
+                .collect(Collectors.toSet());
+
+        final Set<Component> components = configurations.stream().flatMap(configuration -> {
                 final Set<Component> componentsFromConfig = Collections.synchronizedSet(new LinkedHashSet<>());
                 final ResolvedConfiguration resolvedConfiguration = configuration.getResolvedConfiguration();
                 final List<String> depsFromConfig = Collections.synchronizedList(new ArrayList<>());


### PR DESCRIPTION
This creates a copy of configuration to resolve before starting to collect components. some gradle plugin create configuration while resolving configuration. This ends up in `ConcurrentModificationException`.

close #106 
close #99 