### PR TITLE
Metadata filtering for tool in sbom

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.12.0'
@@ -35,6 +34,22 @@ targetCompatibility = JavaVersion.VERSION_1_8
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
+
+def pluginProperties = [
+        'vendor': 'CycloneDX',
+        'name': 'CycloneDX Gradle plugin',
+        'version': project.version,
+        'groupId': project.group,
+        'artifactId': project.name,
+] as Properties
+
+def filterPluginProperties = tasks.register('filterPluginProperties', Copy) {
+    destinationDir = file("$buildDir/resources/filter")
+    inputs.properties pluginProperties
+    from('src/main/filter')
+    expand(pluginProperties)
+}
+sourceSets.main.resources.srcDirs filterPluginProperties
 
 pluginBundle {
     website = 'https://cyclonedx.org'

--- a/src/main/filter/cyclonedx-gradle-plugin.properties
+++ b/src/main/filter/cyclonedx-gradle-plugin.properties
@@ -1,0 +1,7 @@
+# Automatically populated by Gradle build - do not modify
+vendor=${vendor}
+name=${name}
+version=${version}
+groupId=${groupId}
+artifactId=${artifactId}
+timestamp=${System.currentTimeMillis()}

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -280,9 +280,9 @@ public class CycloneDxTask extends DefaultTask {
     private Properties readPluginProperties() {
         final Properties props = new Properties();
         try {
-            props.load(this.getClass().getClassLoader().getResourceAsStream("plugin.properties"));
+            props.load(this.getClass().getClassLoader().getResourceAsStream("cyclonedx-gradle-plugin.properties"));
         } catch (NullPointerException | IOException e) {
-            getLogger().warn("Unable to load plugin.properties", e);
+            getLogger().warn("cyclonedx-gradle-plugin.properties", e);
         }
         return props;
     }

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -1,7 +1,0 @@
-# Automatically populated by Maven build - do not modify
-vendor=${project.organization.name}
-name=${project.name}
-groupId=${project.groupId}
-artifactId=${project.artifactId}
-version=${project.version}
-timestamp=${timestamp}


### PR DESCRIPTION
Hello Steve Springett.

I noticed the gradle plugin didn't fill inn the metadata of the tool producing the SBOM.

This pull request adds filtering capability to the gradle build. 
Also, the commons-io dependency is replaced with use of the standard JDK-api. 

I've successfully verified the contents of the property file as well as outputted XML and JSON files. 
This produces similar data as what the maven plugin does. 

What I'm uncertain of is the format of the value for "timestamp" as it is left unexpanded by the maven plugin. 
The [SBOM 1.4 schema ](https://github.com/CycloneDX/specification/blob/master/schema/bom-1.4.xsd#L149) doesn't specify this explicitly.
Is this field unused and to be removed or should it be formatted in a certain way? 