### PR TITLE
Declare output directory

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -47,6 +47,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import javax.xml.parsers.ParserConfigurationException;
@@ -106,6 +107,11 @@ public class CycloneDxTask extends DefaultTask {
     @Input
     public List<String> getSkipConfigs() {
     	return skipConfigs;
+    }
+
+    @OutputDirectory
+    public File getOutputDir() {
+        return new File(this.buildDir, "reports");
     }
 
     public void setSkipConfigs(Collection<String> skipConfigs) {
@@ -395,7 +401,7 @@ public class CycloneDxTask extends DefaultTask {
         final BomXmlGenerator bomGenerator = BomGeneratorFactory.createXml(schemaVersion, bom);
         bomGenerator.generate();
         final String bomString = bomGenerator.toXmlString();
-        final File bomFile = new File(buildDir, "reports/bom.xml");
+        final File bomFile = new File(getOutputDir(), "bom.xml");
         getLogger().info(MESSAGE_WRITING_BOM_XML);
         FileUtils.write(bomFile, bomString, StandardCharsets.UTF_8, false);
         getLogger().info(MESSAGE_VALIDATING_BOM);
@@ -413,7 +419,7 @@ public class CycloneDxTask extends DefaultTask {
     private void writeJSONBom(final CycloneDxSchema.Version schemaVersion, final Bom bom) throws IOException {
         final BomJsonGenerator bomGenerator = BomGeneratorFactory.createJson(schemaVersion, bom);
         final String bomString = bomGenerator.toJsonString();
-        final File bomFile = new File(buildDir, "reports/bom.json");
+        final File bomFile = new File(getOutputDir(), "bom.json");
         getLogger().info(MESSAGE_WRITING_BOM_JSON);
         FileUtils.write(bomFile, bomString, StandardCharsets.UTF_8, false);
         getLogger().info(MESSAGE_VALIDATING_BOM);


### PR DESCRIPTION
This pull request adds a method `getOutputDir`, with an `@OutputDirectory` annotation.

This is considered good practice. See
- https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:up_to_date_checks
- https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/OutputDirectory.html

> As part of incremental build, Gradle tests whether any of the task inputs or outputs has changed since the last build. If they haven’t, Gradle can consider the task up to date and therefore skip executing its actions. Also note that incremental build won’t work unless a task has at least one task output, although tasks usually have at least one input as well.

This is important for two reasons:
1. As mentioned above, `OutputDirectory` is needed for incremental builds, to detect when a task is still up-to-date.
2. This also allows the following:

---

Currently, to work with the generated `bom.xml` and `bom.json` files, one has to address them by directory, like this
```groovy
task myCopy(type: Copy) {
    dependsOn(cyclonedxBom)

    from("$buildDir/reports")
    into("$projectDir/copy")
}
```

When an output directory is declared one can streamline the function like this:
```groovy
task myCopy2(type: Copy) {
    from(cyclonedxBom)
    into("$projectDir/copy")
}
```

---

Maybe also solves https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/95