### PR TITLE
Initialize dependabot configuration for gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
This initialize `dependabot` configuration, it could be useful to get dependency update.

@stevespringett could we enable it on the repository ? 