### PR TITLE
Remove jcenter() from repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,6 @@ plugins {
 }
 
 repositories {
-    jcenter()
     mavenCentral()
 }
 


### PR DESCRIPTION
JCenter repository announce a shutdown last year, we should avoid trying to resolve dependencies on that repository.