### PR TITLE
Introduce destination property allowing to configure output

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cyclonedxBom {
     projectType = "application"
     // Specified the version of the CycloneDX specification to use. Defaults to 1.2.
     schemaVersion = "1.2"
+    // Boms destination directory (defaults to build/reports)
+    destination = file("build/reports")
 }
 ```
 

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
@@ -26,7 +26,6 @@ public class CycloneDxPlugin implements Plugin<Project> {
     public void apply(Project project) {
         project.getTasks().register("cyclonedxBom", CycloneDxTask.class, (task) -> {
             task.setGroup("Reporting");
-            task.setBuildDir(project.getBuildDir());
         });
     }
 }

--- a/src/test/groovy/org/cyclonedx/gradle/CycloneDxSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/CycloneDxSpec.groovy
@@ -18,9 +18,6 @@
  */
 package org.cyclonedx.gradle
 
-import org.gradle.api.internal.project.ProjectInternal
-import org.gradle.api.Project
-import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 import org.cyclonedx.model.Metadata
@@ -58,7 +55,6 @@ class CycloneDxPluginSpec extends Specification {
 
     def "cyclonedxBom metadata creation uses project specific values"() {
         expect:
-
         Metadata root = rootProject.tasks.findByName('cyclonedxBom').createMetadata()
         root.component.group == 'group'
         root.component.name == 'root'

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1,0 +1,45 @@
+package org.cyclonedx.gradle
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Specification
+
+
+class PluginConfigurationSpec extends Specification {
+
+    def "simple-project should output boms in build/reports"() {
+        given:
+          File testDir = TestUtils.duplicate("simple-project")
+
+        when:
+            def result = GradleRunner.create()
+                    .withProjectDir(testDir)
+                    .withArguments("cyclonedxBom")
+                    .withPluginClasspath()
+                    .build()
+        then:
+            result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+            File reportDir = new File(testDir, "build/reports")
+
+            assert reportDir.exists()
+            reportDir.listFiles().length == 2
+    }
+
+    def "custom-destination project should output boms in output-dir"() {
+        given:
+        File testDir = TestUtils.duplicate("custom-destination")
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testDir)
+                .withArguments("cyclonedxBom")
+                .withPluginClasspath()
+                .build()
+        then:
+        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+        File reportDir = new File(testDir, "output-dir")
+
+        assert reportDir.exists()
+        reportDir.listFiles().length == 2
+    }
+}

--- a/src/test/groovy/org/cyclonedx/gradle/TestUtils.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/TestUtils.groovy
@@ -1,0 +1,23 @@
+package org.cyclonedx.gradle
+
+import java.nio.file.Files
+
+class TestUtils {
+
+    static File duplicate(String testProject) {
+        def tmpDir = File.createTempDir( "copy", testProject)
+        def baseDir = new File("src/test/resources/test-projects/$testProject").toPath()
+
+        baseDir.eachFileRecurse {path ->
+            def relativePath = baseDir.relativize(path)
+            def targetPath = tmpDir.toPath().resolve(relativePath)
+            if (Files.isDirectory(path)) {
+                targetPath.toFile().mkdirs()
+            } else {
+                Files.copy(path, targetPath)
+            }
+        }
+        return tmpDir
+    }
+
+}

--- a/src/test/resources/test-projects/custom-destination/build.gradle
+++ b/src/test/resources/test-projects/custom-destination/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'org.cyclonedx.bom'
+    id 'java'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.8.11'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version:'1.5.18.RELEASE'
+}
+
+
+cyclonedxBom {
+    destination = file("output-dir")
+}

--- a/src/test/resources/test-projects/custom-destination/settings.gradle
+++ b/src/test/resources/test-projects/custom-destination/settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}

--- a/src/test/resources/test-projects/simple-project/build.gradle
+++ b/src/test/resources/test-projects/simple-project/build.gradle
@@ -1,0 +1,24 @@
+plugins {
+    id 'org.cyclonedx.bom'
+    id 'java'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven {
+        url 'https://oss.sonatype.org/content/repositories/snapshots'
+    }
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.8.11'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version:'1.5.18.RELEASE'
+}

--- a/src/test/resources/test-projects/simple-project/settings.gradle
+++ b/src/test/resources/test-projects/simple-project/settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
This introduce a new property allowing the user to set a destination. 

This also sets the destination as `@OutputDirectory` making the task `UP-TO-DATE` if nothing changed.

This also introduce some integration to validate outputs directories.

close #62 
close #95 