### PR TITLE
Remove usage of deprecated compile configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,13 +12,13 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'org.cyclonedx', name: 'cyclonedx-core-java', version: '5.0.4') {
+    implementation(group: 'org.cyclonedx', name: 'cyclonedx-core-java', version: '5.0.4') {
         // gradle-api already includes an slf4j binding
         exclude group: 'org.apache.logging.log4j', module: 'log4j-slf4j-impl'
     }
-    compile 'commons-codec:commons-codec:1.15'
-    compile 'commons-io:commons-io:2.8.0'
-    compile 'org.apache.maven:maven-core:3.5.0'
+    implementation 'commons-codec:commons-codec:1.15'
+    implementation 'commons-io:commons-io:2.8.0'
+    implementation 'org.apache.maven:maven-core:3.5.0'
 
     testImplementation gradleTestKit()
     testImplementation("org.spockframework:spock-core:1.1-groovy-2.4") {


### PR DESCRIPTION
This leverage the `implementation` configuration for project dependencies.

