### PR TITLE
Declare all task input as settable property

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,6 @@ __Output CycloneDX Generation Info:__
 gradle cyclonedxBom -info
 ```
 
-__Exclude BOM Serial Number:__
-```bash
-gradle cyclonedxBom -Pcyclonedx.includeBomSerialNumber=false
-```
-
 __build.gradle__ (excerpt)
 ```groovy
 plugins {
@@ -40,6 +35,8 @@ Once a BOM is generated, it will reside at `./build/reports/bom.xml` and `./buil
 
 __Configuration:__
 You can control the configurations included in the BOM:
+
+
 ```groovy
 cyclonedxBom {
     // includeConfigs is the list of configuration names to include when generating the BOM (leave empty to include every configuration)
@@ -52,7 +49,21 @@ cyclonedxBom {
     schemaVersion = "1.2"
     // Boms destination directory (defaults to build/reports)
     destination = file("build/reports")
+    // Exclude BOM Serial Number
+    includeBomSerialNumber = false
 }
+```
+
+If you are using the Kotlin DSL, the plugin can be configured as following:
+
+```
+tasks.cyclonedxBom {
+    setIncludeConfigs(["runtimeClasspath"])
+    setSkipConfigs(["compileClasspath", "testCompileClasspath"])
+    setProjectType("application")
+    setSchemaVersion("1.4")
+    setDestination(project.file("build/reports"))
+    setincludeBomSerialNumber(false)
 ```
 
 Run gradle with info logging (-i option) to see which configurations add to the BOM. 

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ dependencies {
     }
 }
 
+test {
+    useJUnit()
+}
+
 group = 'org.cyclonedx'
 version = '1.5.1'
 

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -47,6 +47,7 @@ import org.gradle.api.artifacts.ModuleVersionIdentifier;
 import org.gradle.api.artifacts.ResolvedArtifact;
 import org.gradle.api.artifacts.ResolvedConfiguration;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
@@ -83,11 +84,14 @@ public class CycloneDxTask extends DefaultTask {
     private static final String MESSAGE_VALIDATION_FAILURE = "The BOM does not conform to the CycloneDX BOM standard";
     private static final String MESSAGE_SKIPPING = "Skipping CycloneDX";
 
+    private static final String DEFAULT_PROJECT_TYPE = "library";
+
     private File destination;
     private MavenHelper mavenHelper;
-    private CycloneDxSchema.Version schemaVersion = CycloneDxSchema.Version.VERSION_13;
+
     private boolean includeBomSerialNumber;
-    private boolean skip;
+
+    private String schemaVersion;
     private String projectType;
     private final List<String> includeConfigs = new ArrayList<>();
     private final List<String> skipConfigs = new ArrayList<>();
@@ -96,6 +100,9 @@ public class CycloneDxTask extends DefaultTask {
 
     public CycloneDxTask() {
         this.destination = new File(getProject().getBuildDir(), "reports");
+        this.schemaVersion = CycloneDxSchema.Version.VERSION_13.getVersionString();
+        this.projectType = DEFAULT_PROJECT_TYPE;
+        this.includeBomSerialNumber = true;
     }
 
     @Input
@@ -118,6 +125,33 @@ public class CycloneDxTask extends DefaultTask {
     	this.skipConfigs.addAll(skipConfigs);
     }
 
+    @Input
+    public String getSchemaVersion() {
+        return schemaVersion;
+    }
+
+    public void setSchemaVersion(String schemaVersion) {
+        this.schemaVersion = schemaVersion;
+    }
+
+    @Input
+    public String getProjectType() {
+        return projectType;
+    }
+
+    public void setProjectType(String projectType) {
+        this.projectType = projectType;
+    }
+
+    @Input
+    public boolean getIncludeBomSerialNumber() {
+        return this.includeBomSerialNumber;
+    }
+
+    public void setIncludeBomSerialNumber(boolean includeBomSerialNumber) {
+        this.includeBomSerialNumber = includeBomSerialNumber;
+    }
+
     @OutputDirectory
     public File getDestination() {
         return destination;
@@ -128,26 +162,19 @@ public class CycloneDxTask extends DefaultTask {
     }
 
 
-    private void initialize() {
-        schemaVersion = schemaVersion();
-        mavenHelper = new MavenHelper(getLogger(), schemaVersion);
-        if (schemaVersion == CycloneDxSchema.Version.VERSION_10) {
-            includeBomSerialNumber = false;
-        } else {
-            includeBomSerialNumber = getBooleanParameter("cyclonedx.includeBomSerialNumber", true);
+    private CycloneDxSchema.Version computeSchemaVersion() {
+        CycloneDxSchema.Version version = schemaVersion();
+        mavenHelper = new MavenHelper(getLogger(), version);
+        if (version == CycloneDxSchema.Version.VERSION_10) {
+             setIncludeBomSerialNumber(false);
         }
-        skip = getBooleanParameter("cyclonedx.skip", false);
-        projectType = getStringParameter("projectType", "library");
+        return version;
     }
 
     @TaskAction
     @SuppressWarnings("unused")
     public void createBom() {
-        initialize();
-        if (skip) {
-            getLogger().info(MESSAGE_SKIPPING);
-            return;
-        }
+        CycloneDxSchema.Version version = computeSchemaVersion();
         logParameters();
         getLogger().info(MESSAGE_RESOLVING_DEPS);
         final Set<String> builtDependencies = getProject()
@@ -177,7 +204,7 @@ public class CycloneDxTask extends DefaultTask {
                     depsFromConfig.add(dependencyName);
 
                     // Convert into a Component and augment with pom metadata if available.
-                    final Component component = convertArtifact(artifact);
+                    final Component component = convertArtifact(artifact, version);
                     augmentComponentMetadata(component, dependencyName);
                     componentsFromConfig.add(component);
                 });
@@ -187,7 +214,7 @@ public class CycloneDxTask extends DefaultTask {
             })
             .collect(Collectors.toSet());
 
-        writeBom(metadata, components);
+        writeBom(metadata, components, version);
     }
 
     private boolean canBeResolved(Configuration configuration) {
@@ -301,7 +328,7 @@ public class CycloneDxTask extends DefaultTask {
 
     private Component.Type resolveProjectType() {
         for (Component.Type type: Component.Type.values()) {
-            if (type.getTypeName().equalsIgnoreCase(this.projectType)) {
+            if (type.getTypeName().equalsIgnoreCase(getProjectType())) {
                 return type;
             }
         }
@@ -313,7 +340,7 @@ public class CycloneDxTask extends DefaultTask {
         return Component.Type.LIBRARY;
     }
 
-    private Component convertArtifact(ResolvedArtifact artifact) {
+    private Component convertArtifact(ResolvedArtifact artifact, CycloneDxSchema.Version version) {
         final Component component = new Component();
         component.setGroup(artifact.getModuleVersion().getId().getGroup());
         component.setName(artifact.getModuleVersion().getId().getName());
@@ -322,7 +349,7 @@ public class CycloneDxTask extends DefaultTask {
         getLogger().debug(MESSAGE_CALCULATING_HASHES);
         List<Hash> hashes = artifactHashes.computeIfAbsent(artifact.getFile(), f -> {
             try {
-                return BomUtils.calculateHashes(f, schemaVersion);
+                return BomUtils.calculateHashes(f, version);
             } catch(IOException e) {
                 getLogger().error("Error encountered calculating hashes", e);
             }
@@ -383,18 +410,21 @@ public class CycloneDxTask extends DefaultTask {
      * @param metadata The CycloneDX metadata object
      * @param components The CycloneDX components extracted from gradle dependencies
      */
-    protected void writeBom(Metadata metadata, Set<Component> components) throws GradleException{
+    protected void writeBom(Metadata metadata, Set<Component> components, CycloneDxSchema.Version version) throws GradleException{
         try {
             getLogger().info(MESSAGE_CREATING_BOM);
             final Bom bom = new Bom();
-            if (CycloneDxSchema.Version.VERSION_10 != schemaVersion && includeBomSerialNumber) {
+            
+            boolean includeSerialNumber = getBooleanParameter("cyclonedx.includeBomSerialNumber", includeBomSerialNumber);
+
+            if (CycloneDxSchema.Version.VERSION_10 != version && includeSerialNumber) {
                 bom.setSerialNumber("urn:uuid:" + UUID.randomUUID().toString());
             }
             bom.setMetadata(metadata);
             bom.setComponents(new ArrayList<>(components));
-            writeXMLBom(schemaVersion, bom);
+            writeXMLBom(version, bom);
             if (schemaVersion().getVersion() >= 1.2) {
-                writeJSONBom(schemaVersion, bom);
+                writeJSONBom(version, bom);
             }
         } catch (GeneratorException | ParserConfigurationException | IOException e) {
             throw new GradleException("An error occurred executing " + this.getClass().getName(), e);
@@ -439,6 +469,22 @@ public class CycloneDxTask extends DefaultTask {
         }
     }
 
+    /**
+     * Resolves the CycloneDX schema the mojo has been requested to use.
+     * @return the CycloneDX schema to use
+     */
+    private CycloneDxSchema.Version schemaVersion() {
+        final String version = getSchemaVersion();
+        if ("1.0".equals(version)) {
+            return CycloneDxSchema.Version.VERSION_10;
+        } else if ("1.1".equals(version)) {
+            return CycloneDxSchema.Version.VERSION_11;
+        } else if ("1.2".equals(version)) {
+            return CycloneDxSchema.Version.VERSION_12;
+        }
+        return CycloneDxSchema.Version.VERSION_13;
+    }
+
     private boolean getBooleanParameter(String parameter, boolean defaultValue) {
         final Project project = super.getProject();
         if (project.hasProperty(parameter)) {
@@ -450,44 +496,11 @@ public class CycloneDxTask extends DefaultTask {
         return defaultValue;
     }
 
-    private String getStringParameter(String parameter, String defaultValue) {
-        final Project project = super.getProject();
-        if (project.hasProperty(parameter)) {
-            final Object o = project.getProperties().get(parameter);
-            if (o instanceof String) {
-                return (String)o;
-            }
-        }
-        return defaultValue;
-    }
-
-    /**
-     * Resolves the CycloneDX schema the mojo has been requested to use.
-     * @return the CycloneDX schema to use
-     */
-    private CycloneDxSchema.Version schemaVersion() {
-        final Project project = super.getProject();
-        final String version;
-        if (project.hasProperty("cyclonedx.schemaVersion")) {
-            version = (String)project.getProperties().get("cyclonedx.schemaVersion");
-        } else {
-            version = getStringParameter("schemaVersion", CycloneDxSchema.Version.VERSION_13.getVersionString());
-        }
-        if ("1.0".equals(version)) {
-            return CycloneDxSchema.Version.VERSION_10;
-        } else if ("1.1".equals(version)) {
-            return CycloneDxSchema.Version.VERSION_11;
-        } else if ("1.2".equals(version)) {
-            return CycloneDxSchema.Version.VERSION_12;
-        }
-        return CycloneDxSchema.Version.VERSION_13;
-    }
-
     protected void logParameters() {
         if (getLogger().isInfoEnabled()) {
             getLogger().info("CycloneDX: Parameters");
             getLogger().info("------------------------------------------------------------------------");
-            getLogger().info("schemaVersion          : " + schemaVersion.name());
+            getLogger().info("schemaVersion          : " + schemaVersion);
             getLogger().info("includeBomSerialNumber : " + includeBomSerialNumber);
             getLogger().info("------------------------------------------------------------------------");
         }

--- a/src/test/createbom.sh
+++ b/src/test/createbom.sh
@@ -3,5 +3,4 @@
 # NOTE: In order to test un-released SNAPSHOTs locally or on oss.sonatype.org,
 # Gradle v4.1 or higher is required.
 
-gradle publishToMavenLocal
 gradle cyclonedxBom

--- a/src/test/groovy/org/cyclonedx/gradle/CycloneDxSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/CycloneDxSpec.groovy
@@ -22,7 +22,7 @@ import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 import org.cyclonedx.model.Metadata
 
-class CycloneDxPluginSpec extends Specification {
+class CycloneDxSpec extends Specification {
     static final String PLUGIN_ID = 'org.cyclonedx.bom'
     
     def rootProject = ProjectBuilder.builder().withName("root").build()

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -42,4 +42,26 @@ class PluginConfigurationSpec extends Specification {
         assert reportDir.exists()
         reportDir.listFiles().length == 2
     }
+
+    def "kotlin-dsl-project should allow configuring all properties"() {
+        given:
+        File testDir = TestUtils.duplicate("kotlin-dsl-project")
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testDir)
+                .withArguments("cyclonedxBom")
+                .withPluginClasspath()
+                .build()
+
+        then:
+        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+        File reportDir = new File(testDir, "build/reports")
+
+        assert reportDir.exists()
+        reportDir.listFiles().length == 2
+        File jsonBom = new File(reportDir, "bom.json")
+        assert !jsonBom.text.contains("serialNumber")
+    }
+
 }

--- a/src/test/resources/test-projects/kotlin-dsl-project/build.gradle.kts
+++ b/src/test/resources/test-projects/kotlin-dsl-project/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    java
+    id("org.cyclonedx.bom") version "1.5.1"
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.8.11")
+    implementation("org.springframework.boot:spring-boot-starter-web:1.5.18.RELEASE")
+}
+
+tasks.cyclonedxBom {
+    setIncludeBomSerialNumber(false)
+}

--- a/src/test/resources/test-projects/kotlin-dsl-project/settings.gradle.kts
+++ b/src/test/resources/test-projects/kotlin-dsl-project/settings.gradle.kts
@@ -1,0 +1,8 @@
+rootProject.name = "kotlin-dsl-project"
+pluginManagement {
+    repositories {
+        mavenLocal()
+
+        mavenCentral()
+    }
+}


### PR DESCRIPTION
This declare all input as task property. This can then be set by both groovy and kotlin DSL. 

I removed the `skip` property as gradle provide the `-x` flag to skip a task and the `skip` property was not documented.

close #138 