### PR TITLE
Populating plugin.properties on build to address #119

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *~
 /build/
 /.gradle/
+/src/main/resources/plugin.properties

--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,16 @@ test {
     useJUnit()
 }
 
+project.ext.organization = 'CycloneDX'
 group = 'org.cyclonedx'
 version = '1.5.1'
+
+// populate properties into plugin.properties at build time
+ant.propertyfile(file: "src/main/resources/plugin.properties") {
+  entry(key: "vendor", value: project.ext.organization)
+  entry(key: "name", value: project.name)
+  entry(key: "version", value: project.version)
+}
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/resources/plugin.properties
+++ b/src/main/resources/plugin.properties
@@ -1,7 +1,4 @@
-# Automatically populated by Maven build - do not modify
-vendor=${project.organization.name}
-name=${project.name}
-groupId=${project.groupId}
-artifactId=${project.artifactId}
-version=${project.version}
-timestamp=${timestamp}
+# Automatically populated by Gradle build - do not modify
+vendor=
+name=
+version=


### PR DESCRIPTION
While integrating the Gradle plugin into some of my company's projects, I noticed the `plugin.properties` was no longer being updated since the move away from using Maven. This PR should close #119, which already reports the problem this causes with the BOM meta-data.

Let me know if there's a better way of doing this, as my Gradle isn't strong.