### PR TITLE
Add configuration for outputName

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ plugins {
 }
 ```
 
-Once a BOM is generated, it will reside at `./build/reports/bom.xml` and `./build/reports/bom.json`
+Once a BOM is generated, by default it will reside at `./build/reports/bom.xml` and `./build/reports/bom.json`
 
 
 __Configuration:__
@@ -43,12 +43,14 @@ cyclonedxBom {
     includeConfigs += ["runtimeClasspath"]
     // skipConfigs is a list of configuration names to exclude when generating the BOM
     skipConfigs += ["compileClasspath", "testCompileClasspath"]
-    // Specified the type of project being built. Defaults to 'library' 
+    // Specified the type of project being built. Defaults to 'library'
     projectType = "application"
     // Specified the version of the CycloneDX specification to use. Defaults to 1.2.
     schemaVersion = "1.2"
     // Boms destination directory (defaults to build/reports)
     destination = file("build/reports")
+    // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
+    outputName = "bom"
     // Exclude BOM Serial Number
     includeBomSerialNumber = false
 }
@@ -63,15 +65,16 @@ tasks.cyclonedxBom {
     setProjectType("application")
     setSchemaVersion("1.4")
     setDestination(project.file("build/reports"))
+    setOutputName("bom")
     setincludeBomSerialNumber(false)
 ```
 
-Run gradle with info logging (-i option) to see which configurations add to the BOM. 
+Run gradle with info logging (-i option) to see which configurations add to the BOM.
 
 ## CycloneDX Schema Support
 
-The following table provides information on the version of this node module, the CycloneDX schema version supported, 
-as well as the output format options. Use the latest possible version of this node module that is the compatible with 
+The following table provides information on the version of this node module, the CycloneDX schema version supported,
+as well as the output format options. Use the latest possible version of this node module that is the compatible with
 the CycloneDX version supported by the target system.
 
 | Version | Schema Version | Format(s) |

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -92,6 +92,7 @@ public class CycloneDxTask extends DefaultTask {
     private boolean includeBomSerialNumber;
 
     private String schemaVersion;
+    private String outputName;
     private String projectType;
     private final List<String> includeConfigs = new ArrayList<>();
     private final List<String> skipConfigs = new ArrayList<>();
@@ -99,10 +100,20 @@ public class CycloneDxTask extends DefaultTask {
     private final Map<String, MavenProject> resolvedMavenProjects = Collections.synchronizedMap(new HashMap<>());
 
     public CycloneDxTask() {
+        this.outputName = "bom";
         this.destination = new File(getProject().getBuildDir(), "reports");
         this.schemaVersion = CycloneDxSchema.Version.VERSION_13.getVersionString();
         this.projectType = DEFAULT_PROJECT_TYPE;
         this.includeBomSerialNumber = true;
+    }
+
+    @Input
+    public String getOutputName() {
+        return outputName;
+    }
+
+    public void setOutputName(String outputName) {
+        this.outputName = outputName;
     }
 
     @Input
@@ -414,7 +425,7 @@ public class CycloneDxTask extends DefaultTask {
         try {
             getLogger().info(MESSAGE_CREATING_BOM);
             final Bom bom = new Bom();
-            
+
             boolean includeSerialNumber = getBooleanParameter("cyclonedx.includeBomSerialNumber", includeBomSerialNumber);
 
             if (CycloneDxSchema.Version.VERSION_10 != version && includeSerialNumber) {
@@ -436,7 +447,7 @@ public class CycloneDxTask extends DefaultTask {
         final BomXmlGenerator bomGenerator = BomGeneratorFactory.createXml(schemaVersion, bom);
         bomGenerator.generate();
         final String bomString = bomGenerator.toXmlString();
-        final File bomFile = new File(destination, "bom.xml");
+        final File bomFile = new File(destination, outputName + ".xml");
         getLogger().info(MESSAGE_WRITING_BOM_XML);
         FileUtils.write(bomFile, bomString, StandardCharsets.UTF_8, false);
         getLogger().info(MESSAGE_VALIDATING_BOM);
@@ -454,7 +465,7 @@ public class CycloneDxTask extends DefaultTask {
     private void writeJSONBom(final CycloneDxSchema.Version schemaVersion, final Bom bom) throws IOException {
         final BomJsonGenerator bomGenerator = BomGeneratorFactory.createJson(schemaVersion, bom);
         final String bomString = bomGenerator.toJsonString();
-        final File bomFile = new File(destination, "bom.json");
+        final File bomFile = new File(destination, outputName + ".json");
         getLogger().info(MESSAGE_WRITING_BOM_JSON);
         FileUtils.write(bomFile, bomString, StandardCharsets.UTF_8, false);
         getLogger().info(MESSAGE_VALIDATING_BOM);
@@ -502,6 +513,10 @@ public class CycloneDxTask extends DefaultTask {
             getLogger().info("------------------------------------------------------------------------");
             getLogger().info("schemaVersion          : " + schemaVersion);
             getLogger().info("includeBomSerialNumber : " + includeBomSerialNumber);
+            getLogger().info("includeConfigs         : " + includeConfigs);
+            getLogger().info("skipConfigs            : " + skipConfigs);
+            getLogger().info("destination            : " + destination);
+            getLogger().info("outputName             : " + outputName);
             getLogger().info("------------------------------------------------------------------------");
         }
     }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -43,6 +43,23 @@ class PluginConfigurationSpec extends Specification {
         reportDir.listFiles().length == 2
     }
 
+    def "custom-output project should write boms under my-bom"() {
+        given:
+        File testDir = TestUtils.duplicate("custom-outputname")
+
+        when:
+        def result = GradleRunner.create()
+                .withProjectDir(testDir)
+                .withArguments("cyclonedxBom")
+                .withPluginClasspath()
+                .build()
+        then:
+        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+
+        assert new File(testDir, "build/reports/my-bom.json").exists()
+        assert new File(testDir, "build/reports/my-bom.xml").exists()
+    }
+
     def "kotlin-dsl-project should allow configuring all properties"() {
         given:
         File testDir = TestUtils.duplicate("kotlin-dsl-project")

--- a/src/test/resources/test-projects/custom-outputname/build.gradle
+++ b/src/test/resources/test-projects/custom-outputname/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'org.cyclonedx.bom'
+    id 'java'
+    id 'maven-publish'
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.8.11'
+    implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version:'1.5.18.RELEASE'
+}
+
+
+cyclonedxBom {
+    outputName = "my-bom"
+}

--- a/src/test/resources/test-projects/custom-outputname/settings.gradle
+++ b/src/test/resources/test-projects/custom-outputname/settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
Resolves #143 by adding the same `outputName` configuration from the Maven plugin to the Gradle plugin.

I've also added some additional parameters to the logging that were missing around skip/include configs.