### PR TITLE
Use ReaderFactory.newXmlReader() instead of ISR in MavenHelper

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/MavenHelper.java
+++ b/src/main/java/org/cyclonedx/gradle/MavenHelper.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
@@ -39,6 +40,7 @@ import org.apache.maven.model.building.*;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.resolution.ModelResolver;
 import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.cyclonedx.CycloneDxSchema;
 import org.cyclonedx.model.Component;
@@ -288,7 +290,7 @@ class MavenHelper {
     MavenProject readPom(File file) {
         try {
             final MavenXpp3Reader mavenreader = new MavenXpp3Reader();
-            try (final InputStreamReader reader = new InputStreamReader(new BOMInputStream(new FileInputStream(file)))) {
+            try (final Reader reader = ReaderFactory.newXmlReader(file)) {
                 final Model model = mavenreader.read(reader);
                 return new MavenProject(model);
             }
@@ -306,7 +308,7 @@ class MavenHelper {
     MavenProject readPom(InputStream in) {
         try {
             final MavenXpp3Reader mavenreader = new MavenXpp3Reader();
-            try (final InputStreamReader reader = new InputStreamReader(in)) {
+            try (final Reader reader = ReaderFactory.newXmlReader(in)) {
                 final Model model = mavenreader.read(reader);
                 return new MavenProject(model);
             }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -81,4 +81,23 @@ class PluginConfigurationSpec extends Specification {
         assert !jsonBom.text.contains("serialNumber")
     }
 
+    def "pom-xml-encoding project should not output errors to console"() {
+        given:
+        File testDir = TestUtils.duplicate("pom-xml-encoding")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments("cyclonedxBom")
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+        File reportDir = new File(testDir, "build/reports")
+        assert reportDir.exists()
+        reportDir.listFiles().length == 2
+
+        assert !result.output.contains("An error occurred attempting to read POM")
+    }
 }

--- a/src/test/resources/test-projects/pom-xml-encoding/build.gradle
+++ b/src/test/resources/test-projects/pom-xml-encoding/build.gradle
@@ -1,0 +1,19 @@
+// https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/107
+
+plugins {
+    id 'org.cyclonedx.bom'
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+dependencies {
+    // Has declaration with encoding: <?xml version="1.0" encoding="ISO-8859-1"?>
+    implementation group: 'org.easymock', name: 'easymock', version: '3.4'
+}

--- a/src/test/resources/test-projects/pom-xml-encoding/settings.gradle
+++ b/src/test/resources/test-projects/pom-xml-encoding/settings.gradle
@@ -1,0 +1,6 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}


### PR DESCRIPTION
plexus-utils's MXParser obtains encoding from XmlReader (see https://github.com/codehaus-plexus/plexus-utils/issues/163) or from ISR.
In our case MavenHelper creates ISR, and it then reports "default" encoding, which most probably will be UTF-8.

When the pom file contains encoding declaration with something else, like ISO-8859-1 in https://repo1.maven.org/maven2/org/apache/commons/commons-parent/48/commons-parent-48.pom, this results in the error:

```
An error occurred attempting to read POM
org.codehaus.plexus.util.xml.pull.XmlPullParserException: UTF-8 BOM plus xml decl of iso-8859-1 is incompatible (position: START_DOCUMENT seen <?xml version="1.0" encoding="iso-8859-1"... @1:41)
	at org.codehaus.plexus.util.xml.pull.MXParser.parseXmlDeclWithVersion(MXParser.java:3366)
	at org.codehaus.plexus.util.xml.pull.MXParser.parseXmlDecl(MXParser.java:3288)
```

This PR switches to using plexus-utils's ReaderFactory, which "knows better".  This eliminates the above error.