### PR TITLE
fix: CycloneDx schema version to support 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ If you are using the Kotlin DSL, the plugin can be configured as following:
 
 ```kotlin
 tasks.cyclonedxBom {
-    setIncludeConfigs(["runtimeClasspath"])
-    setSkipConfigs(["compileClasspath", "testCompileClasspath"])
+    setIncludeConfigs(listOf("runtimeClasspath"))
+    setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
     setProjectType("application")
     setSchemaVersion("1.4")
     setDestination(project.file("build/reports"))

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ cyclonedxBom {
 
 If you are using the Kotlin DSL, the plugin can be configured as following:
 
-```
+```kotlin
 tasks.cyclonedxBom {
     setIncludeConfigs(["runtimeClasspath"])
     setSkipConfigs(["compileClasspath", "testCompileClasspath"])
@@ -67,6 +67,7 @@ tasks.cyclonedxBom {
     setDestination(project.file("build/reports"))
     setOutputName("bom")
     setincludeBomSerialNumber(false)
+}
 ```
 
 Run gradle with info logging (-i option) to see which configurations add to the BOM.

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -486,15 +486,22 @@ public class CycloneDxTask extends DefaultTask {
      * @return the CycloneDX schema to use
      */
     private CycloneDxSchema.Version schemaVersion() {
-        final String version = getSchemaVersion();
-        if ("1.0".equals(version)) {
+        switch (getSchemaVersion()) {
+          case "1.0":
             return CycloneDxSchema.Version.VERSION_10;
-        } else if ("1.1".equals(version)) {
+            break;
+          case "1.1":
             return CycloneDxSchema.Version.VERSION_11;
-        } else if ("1.2".equals(version)) {
+            break;
+          case "1.2":
             return CycloneDxSchema.Version.VERSION_12;
+            break;
+          case "1.3":
+            return CycloneDxSchema.Version.VERSION_13;
+            break;
+          default:
+            return CycloneDxSchema.Version.VERSION_14;
         }
-        return CycloneDxSchema.Version.VERSION_13;
     }
 
     private boolean getBooleanParameter(String parameter, boolean defaultValue) {

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -487,20 +487,11 @@ public class CycloneDxTask extends DefaultTask {
      */
     private CycloneDxSchema.Version schemaVersion() {
         switch (getSchemaVersion()) {
-          case "1.0":
-            return CycloneDxSchema.Version.VERSION_10;
-            break;
-          case "1.1":
-            return CycloneDxSchema.Version.VERSION_11;
-            break;
-          case "1.2":
-            return CycloneDxSchema.Version.VERSION_12;
-            break;
-          case "1.3":
-            return CycloneDxSchema.Version.VERSION_13;
-            break;
-          default:
-            return CycloneDxSchema.Version.VERSION_14;
+          case "1.0": return CycloneDxSchema.Version.VERSION_10;
+          case "1.1": return CycloneDxSchema.Version.VERSION_11;
+          case "1.2": return CycloneDxSchema.Version.VERSION_12;
+          case "1.3": return CycloneDxSchema.Version.VERSION_13;
+          default: return CycloneDxSchema.Version.VERSION_14;
         }
     }
 

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -102,7 +102,7 @@ public class CycloneDxTask extends DefaultTask {
     public CycloneDxTask() {
         this.outputName = "bom";
         this.destination = new File(getProject().getBuildDir(), "reports");
-        this.schemaVersion = CycloneDxSchema.Version.VERSION_13.getVersionString();
+        this.schemaVersion = CycloneDxSchema.Version.VERSION_14.getVersionString();
         this.projectType = DEFAULT_PROJECT_TYPE;
         this.includeBomSerialNumber = true;
     }


### PR DESCRIPTION
### Description

This PR aims to quick fix the default CycloneDx schema version to what is implied by the readme and also adds support to it properly by updating the version switch function.

### Changes

* fix function to determine schema version when set (now supports & defaults to version 1.4)
* set 1.4 to be the default CycloneDx schema
* minor nit fix for `build.gradle.kts` readme section

### Issues

* fix #154 