### PR TITLE
ci: minor cleanups and missed configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
     directory: /
     schedule:
       interval: daily
+    ignore:
+      - dependency-name: org.spockframework:spock-core
+        versions:
+          # groovy 4.0 is not yet supported by Gradle
+          - 2.2-M1-groovy-4.0
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -2,6 +2,8 @@ name: Build CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
     branches:
       - master

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,3 @@
-
 plugins {
     id 'java-gradle-plugin'
     id 'com.gradle.plugin-publish' version '0.21.0'
@@ -53,18 +52,14 @@ pluginBundle {
     website = 'https://cyclonedx.org'
     vcsUrl = 'https://github.com/CycloneDX/cyclonedx-gradle-plugin.git'
     tags = [ 'cyclonedx', 'dependency', 'dependencies', 'owasp', 'inventory', 'bom', 'sbom' ]
-    plugins {
-        cycloneDxPlugin {
-            displayName = 'CycloneDX BOM Generator'
-            description = 'The CycloneDX Gradle plugin creates an aggregate of all direct and transitive dependencies of a project and creates a valid CycloneDX Software Bill of Materials (SBOM).'
-        }
-    }
 }
 
 gradlePlugin {
     plugins {
         cycloneDxPlugin {
             id = 'org.cyclonedx.bom'
+            displayName = 'CycloneDX BOM Generator'
+            description = 'The CycloneDX Gradle plugin creates an aggregate of all direct and transitive dependencies of a project and creates a valid CycloneDX Software Bill of Materials (SBOM).'
             implementationClass = 'org.cyclonedx.gradle.CycloneDxPlugin'
         }
     }


### PR DESCRIPTION
### Description

This PR aims to cleam up a few loose ends left behind in #155 and specifically enables Dependabot for GitHub Actions too.

### Changes

* add GitHub Actions to Dependabot config
* ignore Groovy 4.0 dependency updated (as they are incompatible right now, might want to set that dependency to manual all together :thinking: )
* trigger build only on default-branch pushes and PRs targeting it
* migrate deprecated config values in `build.gradle` to new variant of setting them 

### Issues

* followup to #155 
