### PR TITLE
fix: javadoc warning about version on writeBom

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -453,6 +453,7 @@ public class CycloneDxTask extends DefaultTask {
      * Ported from Maven plugin.
      * @param metadata The CycloneDX metadata object
      * @param components The CycloneDX components extracted from gradle dependencies
+     * @param version The CycloneDX schema version
      */
     protected void writeBom(Metadata metadata, Set<Component> components, CycloneDxSchema.Version version) throws GradleException{
         try {


### PR DESCRIPTION
Fixing the following javadoc warning

```
> Task :javadoc
cyclonedx-gradle-plugin/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java:457: warning: no @param for version
    protected void writeBom(Metadata metadata, Set<Component> components, CycloneDxSchema.Version version) throws GradleException{
                   ^
1 warning
```