### PR TITLE
Add skipProject option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ cyclonedxBom {
     includeConfigs = ["runtimeClasspath"]
     // skipConfigs is a list of configuration names to exclude when generating the BOM
     skipConfigs = ["compileClasspath", "testCompileClasspath"]
+    // skipProjects is a list of project names to exclude when generating the BOM
+    skipProjects = [rootProject.name, "yourTestSubProject"]
     // Specified the type of project being built. Defaults to 'library'
     projectType = "application"
     // Specified the version of the CycloneDX specification to use. Defaults to 1.4.
@@ -66,6 +68,7 @@ If you are using the Kotlin DSL, the plugin can be configured as following:
 tasks.cyclonedxBom {
     setIncludeConfigs(listOf("runtimeClasspath"))
     setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
+    setSkipProjects(listOf(rootProject.name, "yourTestSubProject"))
     setProjectType("application")
     setSchemaVersion("1.4")
     setDestination(project.file("build/reports"))


### PR DESCRIPTION
#77 

As far as I see currently you have two options to use the plugin:

1.) Apply it on the root project
--> Cannot skip subprojects
2.) Apply it on subprojects separately
--> Produces a bom file per subproject. You need to combine those files manually later using cyclonedx-cli merge -> so why use the plugin at all
--> Combining subprojects bom results cause duplications and huge files

This PR adds an option to skip the root and subprojects.