### PR TITLE
Update default task to include a small description of what it does

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
@@ -24,6 +24,9 @@ import org.gradle.api.Project;
 public class CycloneDxPlugin implements Plugin<Project> {
 
     public void apply(Project project) {
-        project.getTasks().register("cyclonedxBom", CycloneDxTask.class, (task) -> task.setGroup("Reporting"));
+        project.getTasks().register("cyclonedxBom", CycloneDxTask.class, (task) -> {
+            task.setGroup("Reporting");
+            task.setDescription("Generates a CycloneDX compliant Software Bill of Materials (SBOM)");
+        });
     }
 }


### PR DESCRIPTION
Ahoy,

Been using the plugin for a while and noticed the default task doesn't have a description on it (so it doesn't describe what its for in `gradlew tasks`). 

Let me know if there's anything better you'd like it.

Cheers