### PR TITLE
Fix support for CycloneDX 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ allprojects{
 ## How to manually modify Metadata
 
 The Plugin makes it possible to manually add Manufacture-Data and Licenses-Data to the Metadata of the BOM. <br>
-The structure of the Metadata is shown on https://cyclonedx.org/docs/1.4/json/#metadata. <br>
+The structure of the Metadata is shown on https://cyclonedx.org/docs/1.5/json/#metadata. <br>
 The editing of the Manufacture and Licenses-Data is optional. If the Manufacture/Licenses-Date isn't edited,
 then the respective structure won't appear in the BOM.
 
@@ -184,7 +184,7 @@ cyclonedxBom {
 It should be noted that some Data like OrganizationalContact, Url, Name,... can be left out. <br>
 OrganizationalEntity can also include multiple OrganizationalContact.
 
-For details look at https://cyclonedx.org/docs/1.4/json/#metadata.
+For details look at https://cyclonedx.org/docs/1.5/json/#metadata.
 
 
 ## Adding Licenses-Data
@@ -263,7 +263,7 @@ cyclonedxBom {
 }
 ```
 ---
-For details of the BOM structure look at https://cyclonedx.org/docs/1.4/json/#metadata.
+For details of the BOM structure look at https://cyclonedx.org/docs/1.5/json/#metadata.
 
 ## CycloneDX Schema Support
 

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -79,7 +79,6 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-
 public class CycloneDxTask extends DefaultTask {
 
     /**
@@ -115,7 +114,7 @@ public class CycloneDxTask extends DefaultTask {
 
     public CycloneDxTask() {
         schemaVersion = getProject().getObjects().property(String.class);
-        schemaVersion.convention(CycloneDxSchema.Version.VERSION_15.getVersionString());
+        schemaVersion.convention(CycloneDxUtils.DEFAULT_SCHEMA_VERSION.getVersionString());
 
         outputName = getProject().getObjects().property(String.class);
         outputName.convention("bom");

--- a/src/main/java/org/cyclonedx/gradle/utils/CycloneDxUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/CycloneDxUtils.java
@@ -4,6 +4,8 @@ import org.cyclonedx.CycloneDxSchema;
 
 public class CycloneDxUtils {
 
+    public static final CycloneDxSchema.Version DEFAULT_SCHEMA_VERSION = CycloneDxSchema.Version.VERSION_15;
+
     /**
      * Resolves the CycloneDX schema the mojo has been requested to use.
      * @return the CycloneDX schema to use
@@ -14,7 +16,9 @@ public class CycloneDxUtils {
             case "1.1": return CycloneDxSchema.Version.VERSION_11;
             case "1.2": return CycloneDxSchema.Version.VERSION_12;
             case "1.3": return CycloneDxSchema.Version.VERSION_13;
-            default: return CycloneDxSchema.Version.VERSION_14;
+            case "1.4": return CycloneDxSchema.Version.VERSION_14;
+            case "1.5": return CycloneDxSchema.Version.VERSION_15;
+            default: return DEFAULT_SCHEMA_VERSION;
         }
     }
 

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1,6 +1,7 @@
 package org.cyclonedx.gradle
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import org.cyclonedx.gradle.utils.CycloneDxUtils
 import org.cyclonedx.model.Bom
 import org.cyclonedx.model.Component
 import org.gradle.testkit.runner.GradleRunner
@@ -27,7 +28,7 @@ class PluginConfigurationSpec extends Specification {
         assert reportDir.exists()
     }
 
-    def "simple-project should output boms in build/reports with version 1.4"() {
+    def "simple-project should output boms in build/reports with default schema version"() {
         given:
           File testDir = TestUtils.duplicate("simple-project")
 
@@ -44,7 +45,7 @@ class PluginConfigurationSpec extends Specification {
             assert reportDir.exists()
             reportDir.listFiles().length == 2
             File jsonBom = new File(reportDir, "bom.json")
-            assert jsonBom.text.contains("\"specVersion\" : \"1.4\"")
+            assert jsonBom.text.contains("\"specVersion\" : \"${CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString}\"")
     }
 
     def "custom-destination project should output boms in output-dir"() {

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -249,7 +249,7 @@ class PluginConfigurationSpec extends Specification {
         assert log4jCore.getBomRef() == 'pkg:maven/org.apache.logging.log4j/log4j-core@2.15.0?type=jar'
     }
 
-    def "multi-module should output boms in build/reports with version 1.4"() {
+    def "multi-module should output boms in build/reports with default version"() {
         given:
         File testDir = TestUtils.duplicate("multi-module")
 
@@ -266,10 +266,10 @@ class PluginConfigurationSpec extends Specification {
         assert reportDir.exists()
         reportDir.listFiles().length == 2
         File jsonBom = new File(reportDir, "bom.json")
-        assert jsonBom.text.contains("\"specVersion\" : \"1.4\"")
+        assert jsonBom.text.contains("\"specVersion\" : \"${CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString}\"")
     }
 
-    def "multi-module with plugin in subproject should output boms in build/reports with version 1.4"() {
+    def "multi-module with plugin in subproject should output boms in build/reports with default version"() {
         given:
         File testDir = TestUtils.duplicate("multi-module-subproject")
 
@@ -286,7 +286,7 @@ class PluginConfigurationSpec extends Specification {
         assert reportDir.exists()
         reportDir.listFiles().length == 2
         File jsonBom = new File(reportDir, "bom.json")
-        assert jsonBom.text.contains("\"specVersion\" : \"1.4\"")
+        assert jsonBom.text.contains("\"specVersion\" : \"${CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString}\"")
     }
 
     def "kotlin-dsl-project should allow configuring all properties"() {


### PR DESCRIPTION
Fix bug causing the CycloneDX 1.5 schema version
to be ignored by the plugin with fallback to 1.4.

Update docs with spec references to version 1.5.

Fixes gh-361