### PR TITLE
fix: check for artifact existence before looking inside for pom.xml

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/MavenHelper.java
+++ b/src/main/java/org/cyclonedx/gradle/MavenHelper.java
@@ -265,7 +265,7 @@ class MavenHelper {
         if (!isDescribedArtifact(artifact)) {
             return null;
         }
-        if (artifact.getFile() != null) {
+        if (artifact.getFile() != null && artifact.getFile().exists()) {
             try {
                 final JarFile jarFile = new JarFile(artifact.getFile());
                 final ModuleVersionIdentifier mid = artifact.getModuleVersion().getId();


### PR DESCRIPTION
Add a check to verify that the artifact does exist on disk before checking for the "pom.xml" inside.

Without this check, I'm getting `NoSuchFileException` in multi-module project (bar has a dependency on foo):

```
> Task :bar:cyclonedxBom
An error occurred attempting to extract POM from artifact
java.nio.file.NoSuchFileException: /Users/cuong.tran/git/gradle/hello-project/foo/build/libs/foo-25.9e298ae1.0.0.jar
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149)
        at java.base/java.nio.file.Files.readAttributes(Files.java:1764)
        at java.base/java.util.zip.ZipFile$Source.get(ZipFile.java:1259)
        at java.base/java.util.zip.ZipFile$CleanableResource.<init>(ZipFile.java:733)
        at java.base/java.util.zip.ZipFile$CleanableResource.get(ZipFile.java:850)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:248)
        at java.base/java.util.zip.ZipFile.<init>(ZipFile.java:177)
        at java.base/java.util.jar.JarFile.<init>(JarFile.java:350)
        at java.base/java.util.jar.JarFile.<init>(JarFile.java:321)
        at java.base/java.util.jar.JarFile.<init>(JarFile.java:287)
        at org.cyclonedx.gradle.MavenHelper.extractPom(MavenHelper.java:270)
        at org.cyclonedx.gradle.CycloneDxTask.convertArtifact(CycloneDxTask.java:593)
        at org.cyclonedx.gradle.CycloneDxTask.lambda$null$5(CycloneDxTask.java:389)
        at java.base/java.lang.Iterable.forEach(Iterable.java:75)
        at org.cyclonedx.gradle.CycloneDxTask.lambda$createBom$6(CycloneDxTask.java:379)
```