### PR TITLE
fix: move `plugin.properties` to namespaced location

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.withType<ProcessResources> {
     doLast {
         val resourcesDirectory = project.layout.buildDirectory.dir("resources/main")
-        val pluginPropertiesFile = file("${resourcesDirectory.get()}/plugin.properties")
+        val pluginPropertiesFile = file("${resourcesDirectory.get()}/org/cyclonedx/gradle/plugin.properties")
 
         val pluginProperties = Properties()
         pluginProperties["name"] = project.name

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -540,7 +540,7 @@ public class CycloneDxTask extends DefaultTask {
     private Properties readPluginProperties() {
         final Properties props = new Properties();
         try {
-            props.load(this.getClass().getClassLoader().getResourceAsStream("plugin.properties"));
+            props.load(this.getClass().getResourceAsStream("plugin.properties"));
         } catch (NullPointerException | IOException e) {
             getLogger().warn("Unable to load plugin.properties", e);
         }


### PR DESCRIPTION
This solves #336, where `plugin.properties` contributed by other dependencies overwrite the one contained in this plugin.

In my case it was [ktlint-gradle](https://github.com/JLLeitschuh/ktlint-gradle) which also contributed a `plugin.properties` at the root of the classpath (and that won over the one contributed by this plugin).

I tested this locally, and moving it to a namespaced location fixes this problem.