### PR TITLE
Order components and dependencies by purl and ref to have reproducible output

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -389,21 +389,16 @@ public class CycloneDxTask extends DefaultTask {
 
                 resolvedConfiguration.getResolvedArtifacts().forEach(artifact -> {
                     String dependencyName = DependencyUtils.getDependencyName(artifact);
-                    if (builtDependencies.contains(dependencyName)) {
-                        // Resources built as part of this Gradle project will be added to the
-                        // components section but not the dependencies sections
-                        Component component = convertArtifact(artifact, version);
-                        components.putIfAbsent(component.getBomRef(), component);
-                    } else {
-                        // Resources not built as part of this Gradle project will be added to the
-                        // components and dependencies sections. They will also be augmented with
-                        // metadata from their poms
-                        Component component = convertArtifact(artifact, version);
-                        if (getIncludeMetadataResolution().get()) {
+                    Component component = convertArtifact(artifact, version);
+
+                    // Resources not built as part of this Gradle project will be augmented with metadata from their poms
+                    if (!builtDependencies.contains(dependencyName)) {
+                        if(getIncludeMetadataResolution().get()) {
                             augmentComponentMetadata(artifact, component, dependencyName);
                         }
-                        components.putIfAbsent(component.getBomRef(), component);
                     }
+
+                    components.putIfAbsent(component.getBomRef(), component);
                 });
             }
         });

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -338,8 +338,8 @@ public class CycloneDxTask extends DefaultTask {
         getLogger().info(MESSAGE_RESOLVING_DEPS);
         final Set<String> builtDependencies = allBuiltProjects();
 
-        final Map<String, Component> components = new HashMap<>();
-        final Map<String, org.cyclonedx.model.Dependency> dependencies = new HashMap<>();
+        final Map<String, Component> components = new TreeMap<>();
+        final Map<String, org.cyclonedx.model.Dependency> dependencies = new TreeMap<>();
 
         final Metadata metadata = createMetadata();
         Project rootProject = getProject();

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -360,12 +360,8 @@ public class CycloneDxTask extends DefaultTask {
             String projectReference = generatePackageUrl(project);
             for (Configuration configuration : configurations) {
                 final ResolvedConfiguration resolvedConfiguration = configuration.getResolvedConfiguration();
-                final List<String> depsFromConfig = Collections.synchronizedList(new ArrayList<>());
-
                 final org.cyclonedx.model.Dependency moduleDependency = new org.cyclonedx.model.Dependency(projectReference);
-
-                final Set<ResolvedDependency> directModuleDependencies = configuration.getResolvedConfiguration()
-                    .getFirstLevelModuleDependencies();
+                final Set<ResolvedDependency> directModuleDependencies = configuration.getResolvedConfiguration().getFirstLevelModuleDependencies();
 
                 while (directModuleDependencies.stream().anyMatch(this::dependencyWithoutJarArtifact)) {
                     Set<ResolvedDependency> depWithNoArtifacts = directModuleDependencies.stream()
@@ -407,10 +403,8 @@ public class CycloneDxTask extends DefaultTask {
                             augmentComponentMetadata(artifact, component, dependencyName);
                         }
                         components.putIfAbsent(component.getBomRef(), component);
-                        depsFromConfig.add(dependencyName);
                     }
                 });
-                Collections.sort(depsFromConfig);
             }
         });
         addSubProjectsAsComponents(rootDependency, version, projectsToScan, components);


### PR DESCRIPTION
As the components and dependencies are stored in `HashSet` and `HashMap`, when converted to lists, the order is not well defined and seems to change from time to time, especially when run on different computers.

In this PR, components and dependencies are sorted before the BOM is written to have the same order, given same dependencies.

This should fix part of this issue: https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/292