### PR TITLE
chore: Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+# see https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+
+# all maintainers are default-reviewers of new pull requests.
+# see https://github.com/orgs/CycloneDX/teams/gradle-maintainers
+*  @CycloneDX/gradle-maintainers


### PR DESCRIPTION
all maintainers are default-reviewers of new pull requests.
see https://github.com/orgs/CycloneDX/teams/gradle-maintainers