### PR TITLE
fix: fail plugin execution if group, name, or version are not set

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -303,6 +303,11 @@ public class CycloneDxTask extends DefaultTask {
             && !outputFormat.get().trim().equalsIgnoreCase("json")) {
             throw new GradleException("Unsupported output format. Must be one of all, xml, or json");
         }
+        if (getProject().getGroup().equals("")
+            || getProject().getName().isEmpty()
+            || getProject().getVersion().equals("")) {
+            throw new GradleException("Project group, name, and version must be set for the root project");
+        }
 
         CycloneDxSchema.Version version = computeSchemaVersion();
         logParameters();

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -477,4 +477,29 @@ class PluginConfigurationSpec extends Specification {
         assert jsonBom.text.contains("\"specVersion\" : \"1.5\"")
     }
 
+    def "should print error if project group, name, or version unset"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = ''
+            version = ''
+            """, "rootProject.name = 'hello-world'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments("cyclonedxBom")
+            .withPluginClasspath()
+            .run()
+
+        then:
+        result.task(":cyclonedxBom").outcome == TaskOutcome.FAILED
+        assert result.output.contains("Project group, name, and version must be set for the root project")
+    }
 }


### PR DESCRIPTION
Currently the execution is failing anyway, but without providing clear reason to the user 