### PR TITLE
Include local project dependencies as components #432

### DIFF
--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1,6 +1,7 @@
 package org.cyclonedx.gradle
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import groovy.json.JsonSlurper
 import org.cyclonedx.gradle.utils.CycloneDxUtils
 import org.cyclonedx.model.Bom
 import org.cyclonedx.model.Component
@@ -323,7 +324,7 @@ class PluginConfigurationSpec extends Specification {
         assert log4jCore.getBomRef() == 'pkg:maven/org.apache.logging.log4j/log4j-core@2.15.0?type=jar'
     }
 
-    def "multi-module should output boms in build/reports with default version"() {
+    def "multi-module with plugin at root should output boms in build/reports with default version including sub-projects as components"() {
         given:
         File testDir = TestUtils.duplicate("multi-module")
 
@@ -339,11 +340,20 @@ class PluginConfigurationSpec extends Specification {
 
         assert reportDir.exists()
         reportDir.listFiles().length == 2
-        File jsonBom = new File(reportDir, "bom.json")
-        assert jsonBom.text.contains("\"specVersion\" : \"${CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString}\"")
+
+        def jsonBom = loadJsonBom(new File(reportDir, "bom.json"))
+        assert jsonBom.specVersion == CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString
+
+        def appAComponent = JsonBomComponent.of(jsonBom, "pkg:maven/com.example/app-a@1.0.0?type=jar")
+        assert appAComponent.hasComponentDefined()
+        assert !appAComponent.dependsOn("pkg:maven/com.example/app-b@1.0.0?type=jar")
+
+        def appBComponent = JsonBomComponent.of(jsonBom, "pkg:maven/com.example/app-b@1.0.0?type=jar")
+        assert appBComponent.hasComponentDefined()
+        assert appBComponent.dependsOn("pkg:maven/com.example/app-a@1.0.0?type=jar")
     }
 
-    def "multi-module with plugin in subproject should output boms in build/reports with default version"() {
+    def "multi-module with plugin in subproject should output boms in build/reports with for sub-project app-a"() {
         given:
         File testDir = TestUtils.duplicate("multi-module-subproject")
 
@@ -359,8 +369,62 @@ class PluginConfigurationSpec extends Specification {
 
         assert reportDir.exists()
         reportDir.listFiles().length == 2
-        File jsonBom = new File(reportDir, "bom.json")
-        assert jsonBom.text.contains("\"specVersion\" : \"${CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString}\"")
+
+        def jsonBom = loadJsonBom(new File(reportDir, "bom.json"))
+        assert jsonBom.specVersion == CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString
+
+        assert jsonBom.metadata.component.type == "library"
+        assert jsonBom.metadata.component."bom-ref" == "pkg:maven/com.example/app-a@1.0.0?type=jar"
+        assert jsonBom.metadata.component.group == "com.example"
+        assert jsonBom.metadata.component.name == "app-a"
+        assert jsonBom.metadata.component.version == "1.0.0"
+        assert jsonBom.metadata.component.purl == "pkg:maven/com.example/app-a@1.0.0?type=jar"
+
+        def appAComponent = JsonBomComponent.of(jsonBom, "pkg:maven/com.example/app-a@1.0.0?type=jar")
+        assert !appAComponent.hasComponentDefined()
+        assert !appAComponent.dependsOn("pkg:maven/com.example/app-b@1.0.0?type=jar")
+
+        def appBComponent = JsonBomComponent.of(jsonBom, "pkg:maven/com.example/app-b@1.0.0?type=jar")
+        assert !appBComponent.hasComponentDefined()
+        assert appBComponent.dependencies == null
+    }
+
+    def "multi-module with plugin in subproject should output boms in build/reports with for sub-project app-b"() {
+        given:
+        File testDir = TestUtils.duplicate("multi-module-subproject")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(":app-a:assemble", ":app-b:cyclonedxBom", "--info", "-S")
+            .withPluginClasspath()
+            .build()
+        then:
+        result.task(":app-b:cyclonedxBom").outcome == TaskOutcome.SUCCESS
+        File reportDir = new File(testDir, "app-b/build/reports")
+
+        assert reportDir.exists()
+        reportDir.listFiles().length == 2
+
+        def jsonBom = loadJsonBom(new File(reportDir, "bom.json"))
+        assert jsonBom.specVersion == CycloneDxUtils.DEFAULT_SCHEMA_VERSION.versionString
+
+        assert jsonBom.metadata.component.type == "library"
+        assert jsonBom.metadata.component."bom-ref" == "pkg:maven/com.example/app-b@1.0.0?type=jar"
+        assert jsonBom.metadata.component.group == "com.example"
+        assert jsonBom.metadata.component.name == "app-b"
+        assert jsonBom.metadata.component.version == "1.0.0"
+        assert jsonBom.metadata.component.purl == "pkg:maven/com.example/app-b@1.0.0?type=jar"
+
+        def appAComponent = JsonBomComponent.of(jsonBom, "pkg:maven/com.example/app-a@1.0.0?type=jar")
+        assert appAComponent.hasComponentDefined()
+        assert appAComponent.component.hashes != null
+        assert !appAComponent.component.hashes.empty
+        assert !appAComponent.dependsOn("pkg:maven/com.example/app-b@1.0.0?type=jar")
+
+        def appBComponent = JsonBomComponent.of(jsonBom, "pkg:maven/com.example/app-b@1.0.0?type=jar")
+        assert !appBComponent.hasComponentDefined()
+        assert appBComponent.dependsOn("pkg:maven/com.example/app-a@1.0.0?type=jar")
     }
 
     def "kotlin-dsl-project should allow configuring all properties"() {
@@ -575,5 +639,35 @@ class PluginConfigurationSpec extends Specification {
         then:
         result.task(":cyclonedxBom").outcome == TaskOutcome.FAILED
         assert result.output.contains("Project group, name, and version must be set for the root project")
+    }
+
+    private static def loadJsonBom(File file) {
+        return new JsonSlurper().parse(file)
+    }
+
+    private static class JsonBomComponent {
+
+        def component
+        def dependencies
+
+        boolean hasComponentDefined() {
+            return component != null
+                && ["library", "application"].contains(component.type)
+                && !component.group.empty
+                && !component.name.empty
+                && !component.version.empty
+                && !component.purl.empty
+        }
+
+        boolean dependsOn(String ref) {
+            return dependencies != null && dependencies.dependsOn.contains(ref)
+        }
+
+        static JsonBomComponent of(jsonBom, String ref) {
+            return new JsonBomComponent(
+                component: jsonBom.components.find { it."bom-ref".equals(ref) },
+                dependencies: jsonBom.dependencies.find { it.ref.equals(ref) }
+            )
+        }
     }
 }

--- a/src/test/resources/test-projects/multi-module-subproject/app-b/build.gradle
+++ b/src/test/resources/test-projects/multi-module-subproject/app-b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'java'
+    id 'org.cyclonedx.bom' version '1.7.1'
 }
 
 repositories {
@@ -12,4 +13,5 @@ version = '1.0.0'
 
 dependencies {
     implementation 'org.springframework:spring-core:5.3.16'
+    implementation(project(':app-a'))
 }

--- a/src/test/resources/test-projects/multi-module/app-b/build.gradle
+++ b/src/test/resources/test-projects/multi-module/app-b/build.gradle
@@ -12,4 +12,5 @@ version = '1.0.0'
 
 dependencies {
     implementation group: 'org.springframework', name: 'spring-core', version: '5.3.16'
+    implementation(project(':app-a'))
 }


### PR DESCRIPTION
This PR attempts to solve #432

This is done by:

* Simplifying how all projects are added to the `builtDependencies`. Fix #368 which only added direct local project dependencies, but forgot to add transitive ones to local project.
* Not generating the `generateProjectComponent` at the top, but putting it at the end, in a second loop. This allows to compute extra information for the components (for example hashes) if it is part of the dependency graph.
* Ensure dependencies part of `builtDependencies` are added to the `components` field of the BOM, but without triggering any maven lookup for metadata.