### PR TITLE
feat: add includeMetadataResolution property

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ cyclonedxBom {
     includeBomSerialNumber = false
     // Exclude License Text. Defaults to 'true'
     includeLicenseText = false
+    // Include resolution of full metadata for components including licenses. Defaults to 'true'
+    includeMetadataResolution = true
     // Override component version. Defaults to the project version
     componentVersion = "2.0.0"
     // Override component name. Defaults to the project name
@@ -84,6 +86,7 @@ tasks.cyclonedxBom {
     setOutputFormat("json")
     setIncludeBomSerialNumber(false)
     setIncludeLicenseText(true)
+    setIncludeMetadataResolution(true)
     setComponentVersion("2.0.0")
     setComponentName("my-component")
 }

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -106,6 +106,7 @@ public class CycloneDxTask extends DefaultTask {
     private final ListProperty<String> skipConfigs;
     private final ListProperty<String> skipProjects;
     private final Property<File> destination;
+    private final Property<Boolean> includeMetadataResolution;
     private OrganizationalEntity organizationalEntity;
     private LicenseChoice licenseChoice;
     private final Map<File, List<Hash>> artifactHashes = Collections.synchronizedMap(new HashMap<>());
@@ -139,6 +140,9 @@ public class CycloneDxTask extends DefaultTask {
         includeConfigs = getProject().getObjects().listProperty(String.class);
         skipConfigs = getProject().getObjects().listProperty(String.class);
         skipProjects = getProject().getObjects().listProperty(String.class);
+
+        includeMetadataResolution = getProject().getObjects().property(Boolean.class);
+        includeMetadataResolution.convention(true);
 
         destination = getProject().getObjects().property(File.class);
         destination.convention(getProject().getLayout().getBuildDirectory().dir("reports").get().getAsFile());
@@ -245,6 +249,15 @@ public class CycloneDxTask extends DefaultTask {
 
     public void setIncludeBomSerialNumber(boolean includeBomSerialNumber) {
         this.includeBomSerialNumber.set(includeBomSerialNumber);
+    }
+
+    @Input
+    public Property<Boolean> getIncludeMetadataResolution() {
+        return includeMetadataResolution;
+    }
+
+    public void setIncludeMetadataResolution(boolean includeMetadataResolution) {
+        this.includeMetadataResolution.set(includeMetadataResolution);
     }
 
     @OutputDirectory
@@ -390,7 +403,9 @@ public class CycloneDxTask extends DefaultTask {
                         // components and dependencies sections. They will also be augmented with
                         // metadata from their poms
                         Component component = convertArtifact(artifact, version);
-                        augmentComponentMetadata(artifact, component, dependencyName);
+                        if (getIncludeMetadataResolution().get()) {
+                            augmentComponentMetadata(artifact, component, dependencyName);
+                        }
                         components.putIfAbsent(component.getBomRef(), component);
                         depsFromConfig.add(dependencyName);
                     }
@@ -759,14 +774,15 @@ public class CycloneDxTask extends DefaultTask {
         if (getLogger().isInfoEnabled()) {
             getLogger().info("CycloneDX: Parameters");
             getLogger().info("------------------------------------------------------------------------");
-            getLogger().info("schemaVersion          : " + schemaVersion.get());
-            getLogger().info("includeLicenseText     : " + includeLicenseText.get());
-            getLogger().info("includeBomSerialNumber : " + includeBomSerialNumber.get());
-            getLogger().info("includeConfigs         : " + includeConfigs.get());
-            getLogger().info("skipConfigs            : " + skipConfigs.get());
-            getLogger().info("skipProjects           : " + skipProjects.get());
-            getLogger().info("destination            : " + destination.get());
-            getLogger().info("outputName             : " + outputName.get());
+            getLogger().info("schemaVersion             : " + schemaVersion.get());
+            getLogger().info("includeLicenseText        : " + includeLicenseText.get());
+            getLogger().info("includeBomSerialNumber    : " + includeBomSerialNumber.get());
+            getLogger().info("includeConfigs            : " + includeConfigs.get());
+            getLogger().info("skipConfigs               : " + skipConfigs.get());
+            getLogger().info("skipProjects              : " + skipProjects.get());
+            getLogger().info("includeMetadataResolution : " + includeMetadataResolution.get());
+            getLogger().info("destination               : " + destination.get());
+            getLogger().info("outputName                : " + outputName.get());
             getLogger().info("------------------------------------------------------------------------");
         }
     }


### PR DESCRIPTION
**Benchmark on this project**
includeMetadataResolution = true (Default settings) 
```
scenario,default
version,Gradle 8.9
tasks,clean cyclonedxbom
value,total execution time
warm-up build #1,4502.98
warm-up build #2,832.18
warm-up build #3,720.30
warm-up build #4,714.23
warm-up build #5,602.87
warm-up build #6,583.48
measured build #1,568.10
measured build #2,547.08
measured build #3,590.53
measured build #4,534.99
measured build #5,561.41
measured build #6,588.55
measured build #7,559.26
measured build #8,512.95
measured build #9,492.86
measured build #10,530.29
```

includeMetadataResolution = false
```
scenario,default
version,Gradle 8.9
tasks,clean cyclonedxbom
value,total execution time
warm-up build #1,3814.33
warm-up build #2,536.39
warm-up build #3,485.59
warm-up build #4,415.14
warm-up build #5,387.52
warm-up build #6,380.94
measured build #1,387.85
measured build #2,382.01
measured build #3,377.43
measured build #4,374.35
measured build #5,373.14
measured build #6,366.57
measured build #7,358.51
measured build #8,372.37
measured build #9,366.38
measured build #10,364.20
```
