### PR TITLE
fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ cyclonedxBom {
     outputName = "bom"
     // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
     outputFormat = "json"
-    // Exclude BOM Serial Number. Defaults to 'true'
+    // Include BOM Serial Number. Defaults to 'true'
     includeBomSerialNumber = false
-    // Exclude License Text. Defaults to 'true'
+    // Include License Text. Defaults to 'true'
     includeLicenseText = false
     // Include resolution of full metadata for components including licenses. Defaults to 'true'
     includeMetadataResolution = true


### PR DESCRIPTION
Hi,

I was confused about the descriptions of the two parameters in particular in combination with the default values. For me it was totally unclear if e.g the bom serial number is included or excluded by default. I checked the code and it seems to be included by default.

My current understanding is that before my changes line 62 is a comment about the setting in line 63 and not a description of the parameter. In other words, given the `includeBomSerialNumber` parameter is set to `false` the serial number is excluded and therefore the comment reads Exclude instead of Include. However, this is in contrast to all other parameters where the description is independent of the example configuration. 

As the changes are simple I decided to directly create a pull request instead of opening an issue first.

Best regards

TheManWhoStaresAtCode