### PR TITLE
Disable dependency verification during each task when resolving as part of SBOM generation.

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -547,6 +547,7 @@ public class CycloneDxTask extends DefaultTask {
         }
         final Dependency pomDep = getProject().getDependencies().create(dependencyName + "@pom");
         final Configuration pomCfg = getProject().getConfigurations().detachedConfiguration(pomDep);
+        pomCfg.getResolutionStrategy().disableDependencyVerification();
 
         try {
             @Nullable final File pomFile = pomCfg.resolve().stream().findFirst().orElse(null);

--- a/src/main/java/org/cyclonedx/gradle/GradleAssistedMavenModelResolverImpl.java
+++ b/src/main/java/org/cyclonedx/gradle/GradleAssistedMavenModelResolverImpl.java
@@ -45,6 +45,7 @@ public class GradleAssistedMavenModelResolverImpl implements ModelResolver {
         org.gradle.api.artifacts.Dependency dependency =
                 project.getDependencies().create(depNotation);
         Configuration config = project.getConfigurations().detachedConfiguration(dependency);
+        config.getResolutionStrategy().disableDependencyVerification();
 
         File pomXml = config.getSingleFile();
         return new ModelSource2() {


### PR DESCRIPTION
Gradle's dependency verification can have already happened elsewhere by the time these tasks run and its not really the responsibility of the report tasks to take on any of this work.

The `disableDependencyVerification` method was added in Gradle 6.2:
https://docs.gradle.org/current/kotlin-dsl/gradle/org.gradle.api.artifacts/-resolution-strategy/disable-dependency-verification.html

xref https://docs.gradle.org/current/userguide/dependency_verification.html