### PR TITLE
fix: use lenient artifact view

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
@@ -128,7 +128,14 @@ class SbomGraphProvider implements Callable<SbomGraph> {
                 .filter(configuration -> shouldIncludeConfiguration(configuration)
                         && !shouldSkipConfiguration(configuration)
                         && configuration.isCanBeResolved())
-                .flatMap(config -> config.getIncoming().getArtifacts().getArtifacts().stream())
+                .flatMap(config -> config
+                        .getIncoming()
+                        .artifactView(view -> {
+                            view.lenient(true);
+                        })
+                        .getArtifacts()
+                        .getArtifacts()
+                        .stream())
                 .collect(Collectors.toMap(
                         artifact -> artifact.getId().getComponentIdentifier(),
                         ResolvedArtifactResult::getFile,


### PR DESCRIPTION
I do not have a test project to prove this that I can share - however, in local testing, this appears to resolve https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/478

See the [lenient(boolean)](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/ArtifactView.ViewConfiguration.html#lenient(boolean)) JavaDoc for an explanation.