### PR TITLE
fix: use configured componentVersion in PURL

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
@@ -84,8 +84,8 @@ class SbomGraphProvider implements Callable<SbomGraph> {
     }
 
     private SbomGraph buildSbomGraph(final Map<SbomComponentId, SbomComponent> graph) {
-
-        final Optional<SbomComponent> rootProject = DependencyUtils.findRootComponent(project, graph);
+        final Optional<SbomComponent> rootProject = DependencyUtils.findRootComponent(
+                project, graph, task.getComponentVersion().get());
         if (rootProject.isPresent()) {
             DependencyUtils.connectRootWithSubProjects(
                     project, rootProject.get().getId(), graph);
@@ -95,7 +95,7 @@ class SbomGraphProvider implements Callable<SbomGraph> {
             final SbomComponentId rootProjectId = new SbomComponentId(
                     project.getGroup().toString(),
                     project.getName(),
-                    project.getVersion().toString(),
+                    task.getComponentVersion().get(),
                     "");
             final SbomComponent sbomComponent = new SbomComponent.Builder()
                     .withId(rootProjectId)

--- a/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
@@ -78,13 +78,12 @@ public class DependencyUtils {
     }
 
     public static Optional<SbomComponent> findRootComponent(
-            final Project project, final Map<SbomComponentId, SbomComponent> graph) {
+            final Project project,
+            final Map<SbomComponentId, SbomComponent> graph,
+            final String configuredComponentVersion) {
 
-        final SbomComponentId rootProjectId = new SbomComponentId(
-                project.getGroup().toString(),
-                project.getName(),
-                project.getVersion().toString(),
-                "");
+        final SbomComponentId rootProjectId =
+                new SbomComponentId(project.getGroup().toString(), project.getName(), configuredComponentVersion, "");
 
         if (!graph.containsKey(rootProjectId)) {
             return Optional.empty();

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -234,6 +234,7 @@ class PluginConfigurationSpec extends Specification {
         reportDir.listFiles({File file -> file.isFile()} as FileFilter).length == 2
         File jsonBom = new File(reportDir, "bom.json")
         assert jsonBom.text.contains("\"version\" : \"999-SNAPSHOT\"")
+        assert jsonBom.text.contains("\"purl\" : \"pkg:maven/com.example/hello-world@999-SNAPSHOT\"")
     }
 
     def "should use configured projectType"() {


### PR DESCRIPTION
Android applications may not correctly set the core `version` - thus we need to use the configured `componentVersion` to generate the correct PURL.

Resolves #541