### PR TITLE
fix: avoid using deprecated tools section

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ dependencies {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+    maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -50,6 +50,7 @@ import org.cyclonedx.model.LicenseChoice;
 import org.cyclonedx.model.Metadata;
 import org.cyclonedx.model.Property;
 import org.cyclonedx.model.Tool;
+import org.cyclonedx.model.metadata.ToolInformation;
 import org.cyclonedx.util.BomUtils;
 import org.gradle.api.logging.Logger;
 
@@ -125,11 +126,23 @@ class SbomBuilder {
 
         final Properties pluginProperties = readPluginProperties();
         if (!pluginProperties.isEmpty()) {
-            final Tool tool = new Tool();
-            tool.setVendor(pluginProperties.getProperty("vendor"));
-            tool.setName(pluginProperties.getProperty("name"));
-            tool.setVersion(pluginProperties.getProperty("version"));
-            metadata.addTool(tool);
+            // if schema version is 1.5 or higher use tools instead of tool
+            if (version.compareTo(Version.VERSION_15) >= 0) {
+                final Component component = new Component();
+                component.setType(Component.Type.APPLICATION);
+                component.setAuthor(pluginProperties.getProperty("vendor"));
+                component.setName(pluginProperties.getProperty("name"));
+                component.setVersion(pluginProperties.getProperty("version"));
+                final ToolInformation tool = new ToolInformation();
+                tool.setComponents(Collections.singletonList(component));
+                metadata.setToolChoice(tool);
+            } else {
+                final Tool tool = new Tool();
+                tool.setVendor(pluginProperties.getProperty("vendor"));
+                tool.setName(pluginProperties.getProperty("name"));
+                tool.setVersion(pluginProperties.getProperty("version"));
+                metadata.addTool(tool);
+            }
         }
 
         return metadata;


### PR DESCRIPTION
Instead of using the tools section deprecated in 1.5:

```json
"metadata" : {
    "timestamp" : "2024-12-02T22:12:31Z",
    "tools" : [
      {
        "vendor" : "CycloneDX",
        "name" : "cyclonedx-gradle-plugin",
        "version" : "1.10.0"
      }
    ],
```

If using schema 1.5+ the non-deprecated version of tools is used:

```json
  "metadata" : {
    "timestamp" : "2024-12-02T22:15:04Z",
    "tools" : {
      "components" : [
        {
          "type" : "application",
          "author" : "CycloneDX",
          "name" : "cyclonedx-gradle-plugin",
          "version" : "1.11.1"
        }
      ]
    },
```

Note that this PR also begins the work to parallelize the test cases; to improve the build performance the test cases in `DependencyResolutionSpec.groovy` and `PluginConfigurationSpec.groovy` should be moved to their own `*Spec.groovy` file so that they can be run in parallel.