### PR TITLE
feat: retrieve build-system metadata from build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ cyclonedxBom {
     includeLicenseText = false
     // Include resolution of full metadata for components including licenses. Defaults to 'true'
     includeMetadataResolution = true
+    // Attempt to include the build-system URL by reading environment variables from common CI system such as GitHub Actions, GitLab CI, Drone, Jenkins, Travis CI, and Circle CI. Defaults to 'false'
+    includeBuildSystem = true
+    // if includeBuildSystem is true, the given environment variables will be used to construct the build-system URL that will be included in the BOM. Optional, defaults to `null`.
+    buildSystemEnvironmentVariable = '${CUSTOM_CI_URL}/jobs/${CUSTOM_JOB_ID}'
     // Override component version. Defaults to the project version
     componentVersion = "2.0.0"
     // Override component name. Defaults to the project name

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ cyclonedxBom {
     includeMetadataResolution = true
     // Attempt to include the build-system URL by reading environment variables from common CI system such as GitHub Actions, GitLab CI, Drone, Jenkins, Travis CI, and Circle CI. Defaults to 'false'
     includeBuildSystem = true
-    // if includeBuildSystem is true, the given environment variables will be used to construct the build-system URL that will be included in the BOM. Optional, defaults to `null`.
+    // if includeBuildSystem is true, the given environment variables will be used to construct the build-system URL that will be included in the BOM. The dollar sign and curly braces (e.g. `${NAME}`) are required to specify an environment variable. Optional, defaults to `null`.
     buildSystemEnvironmentVariable = '${CUSTOM_CI_URL}/jobs/${CUSTOM_JOB_ID}'
     // Override component version. Defaults to the project version
     componentVersion = "2.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     }
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.11.3")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.11.3")
+    testImplementation("com.github.stefanbirkner:system-lambda:1.2.1")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
+    jvmArgs = listOf("--add-opens", "java.base/java.util=ALL-UNNAMED",
+        "--add-opens", "java.base/java.lang=ALL-UNNAMED")
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,8 +40,12 @@ dependencies {
 tasks.withType<Test> {
     useJUnitPlatform()
     maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
-    jvmArgs = listOf("--add-opens", "java.base/java.util=ALL-UNNAMED",
-        "--add-opens", "java.base/java.lang=ALL-UNNAMED")
+    if (JavaVersion.current().isJava11Compatible()) {
+        jvmArgs = listOf(
+            "--add-opens", "java.base/java.util=ALL-UNNAMED",
+            "--add-opens", "java.base/java.lang=ALL-UNNAMED"
+        )
+    }
 }
 
 tasks.withType<JavaCompile>().configureEach {

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -35,6 +35,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
@@ -61,6 +62,8 @@ public abstract class CycloneDxTask extends DefaultTask {
     private final ListProperty<String> skipProjects;
     private final Property<File> destination;
     private final Provider<SbomGraph> componentsProvider;
+    private final Property<Boolean> includeBuildSystem;
+    private final Property<String> buildSystemEnvironmentVariable;
 
     @Nullable private OrganizationalEntity organizationalEntity;
 
@@ -112,6 +115,10 @@ public abstract class CycloneDxTask extends DefaultTask {
                 .dir("reports")
                 .get()
                 .getAsFile());
+
+        includeBuildSystem = getProject().getObjects().property(Boolean.class);
+        includeBuildSystem.convention(false);
+        buildSystemEnvironmentVariable = getProject().getObjects().property(String.class);
     }
 
     @Input
@@ -220,6 +227,34 @@ public abstract class CycloneDxTask extends DefaultTask {
 
     public void setSkipProjects(final Collection<String> skipProjects) {
         this.skipProjects.addAll(skipProjects);
+    }
+
+    @Input
+    public Property<Boolean> getIncludeBuildSystem() {
+        return includeBuildSystem;
+    }
+
+    public void setIncludeBuildSystem(final boolean includeBuildSystem) {
+        this.includeBuildSystem.set(includeBuildSystem);
+    }
+
+    /**
+     * The environment variable to use to determine the build system URL. If the
+     * build system URL needs to be constructed from multiple environment variables a
+     * pattern can be set using `buildSystemEnvironmentVariable = '${SERVER}/jobs/${JOB_ID}'`.
+     * Note, that when configuring in kotlin or groovy single quotes must be used to prevent the
+     * build itself from interpolating that variables.
+     *
+     * @return the environment variable to use to determine the build system
+     */
+    @Input
+    @Optional
+    public Property<String> getBuildSystemEnvironmentVariable() {
+        return buildSystemEnvironmentVariable;
+    }
+
+    public void setBuildSystemEnvironmentVariable(final String buildSystemEnvironmentVariable) {
+        this.buildSystemEnvironmentVariable.set(buildSystemEnvironmentVariable);
     }
 
     @Internal

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -153,7 +153,7 @@ class SbomBuilder {
         return metadata;
     }
 
-    private void addBuildSystemMetaData(Component component) {
+    private void addBuildSystemMetaData(final Component component) {
         if (task.getIncludeBuildSystem().get()) {
             String url;
             if (task.getBuildSystemEnvironmentVariable().isPresent()

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -167,10 +167,7 @@ class SbomBuilder {
                 ExternalReference buildRef = new ExternalReference();
                 buildRef.setType(ExternalReference.Type.BUILD_SYSTEM);
                 buildRef.setUrl(url);
-                if (component.getExternalReferences() == null) {
-                    component.setExternalReferences(new ArrayList<>());
-                }
-                component.getExternalReferences().add(buildRef);
+                component.addExternalReference(buildRef);
             }
         }
     }

--- a/src/main/java/org/cyclonedx/gradle/utils/EnvironmentUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/EnvironmentUtils.java
@@ -1,0 +1,129 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class EnvironmentUtils {
+
+    /**
+     * Checks if a string is null or blank.
+     * @param value the string to check
+     * @return true if the string is null or blank, false otherwise
+     */
+    private static boolean isNullOrBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    /**
+     * Get the URI of the current build from the environment variables set on common build systems like GitHub Actions, GitLab CI, etc.
+     * @return the URI of the current build or null if it cannot be determined
+     */
+    public static String getBuildURI() {
+        // GitHub Actions
+        String githubServerUrl = System.getenv("GITHUB_SERVER_URL");
+        String githubRepository = System.getenv("GITHUB_REPOSITORY");
+        String githubRunId = System.getenv("GITHUB_RUN_ID");
+
+        if (!isNullOrBlank(githubServerUrl) && !isNullOrBlank(githubRepository) && !isNullOrBlank(githubRunId)) {
+            return String.format("%s/%s/actions/runs/%s", githubServerUrl, githubRepository, githubRunId);
+        }
+
+        // GitLab CI
+        String ciProjectUrl = System.getenv("CI_PROJECT_URL");
+        String ciJobId = System.getenv("CI_JOB_ID");
+        if (!isNullOrBlank(ciProjectUrl) && !isNullOrBlank(ciJobId)) {
+            return String.format("%s/-/jobs/%s", ciProjectUrl, ciJobId);
+        }
+
+        // Jenkins
+        String buildUrl = System.getenv("BUILD_URL");
+        if (!isNullOrBlank(buildUrl)) {
+            return buildUrl;
+        }
+        //        String jobUrl = System.getenv("JOB_URL");
+        //        if (!isNullOrBlank(jobUrl)) {
+        //            return jobUrl;
+        //        }
+
+        // Travis CI
+        String travisBuildUrl = System.getenv("TRAVIS_BUILD_WEB_URL");
+        if (!isNullOrBlank(travisBuildUrl)) {
+            return travisBuildUrl;
+        }
+        //        String travisJobUrl = System.getenv("TRAVIS_JOB_WEB_URL");
+        //        if (!isNullOrBlank(travisJobUrl)) {
+        //            return travisJobUrl;
+        //        }
+
+        // CircleCI
+        String circleBuildUrl = System.getenv("CIRCLE_BUILD_URL");
+        if (!isNullOrBlank(circleBuildUrl)) {
+            return circleBuildUrl;
+        }
+
+        // Drone by Harness
+        String droneBuildUrl = System.getenv("DRONE_BUILD_LINK");
+        if (!isNullOrBlank(droneBuildUrl)) {
+            return droneBuildUrl;
+        }
+        return null;
+    }
+
+    /**
+     * Get the URI of the current build from the specified pattern and environment variables and pattern. An example
+     * pattern could be "${SERVER}/jobs/${JOB_ID}". The environment variables are specified as a list of names.
+     * @param pattern the pattern to use to build the URI
+     * @return the URI of the current build or null if it cannot be determined
+     */
+    private static String getBuildUriFromPattern(String pattern) {
+        String result = pattern;
+        Pattern regex = Pattern.compile("\\$\\{([^}]+)\\}");
+        Matcher matcher = regex.matcher(pattern);
+
+        while (matcher.find()) {
+            String varName = matcher.group(1);
+            if (isNullOrBlank(varName)) {
+                return null;
+            }
+            String value = System.getenv(varName);
+            if (isNullOrBlank(value)) {
+                return null;
+            }
+            result = result.replace("${" + varName + "}", value);
+        }
+        return result;
+    }
+
+    /**
+     * Get the URI of the current build from the specified environment variable.
+     * Additionally, a pattern can be provided to extract the URI from the environment variable.
+     * An example pattern could be "${SERVER}/jobs/${JOB_ID}".
+     *
+     * @param str the name of the environment variable or pattern to use
+     * @return the URI of the current build or null if it cannot be determined
+     */
+    public static String getBuildURI(String str) {
+        if (str.contains("${")) {
+            return getBuildUriFromPattern(str);
+        }
+        return System.getenv(str);
+    }
+}

--- a/src/main/java/org/cyclonedx/gradle/utils/EnvironmentUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/EnvironmentUtils.java
@@ -18,98 +18,48 @@
  */
 package org.cyclonedx.gradle.utils;
 
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 
+/**
+ * Utility class for working with environment variables in common CI environments.
+ */
 public class EnvironmentUtils {
 
     /**
-     * Checks if a string is null or blank.
-     * @param value the string to check
-     * @return true if the string is null or blank, false otherwise
+     * Pattern to match environment variables in a string.
      */
-    private static boolean isNullOrBlank(String value) {
-        return value == null || value.trim().isEmpty();
-    }
+    private static final Pattern VARIABLE_PATTERN = Pattern.compile("\\$\\{([^}]+)}");
+    /**
+     * Jenkins build URL environment variable.
+     */
+    private static final String JENKINS_BUILD_URL = "BUILD_URL";
+    /**
+     * Travis build URL environment variable.
+     */
+    private static final String TRAVIS_BUILD_WEB_URL = "TRAVIS_BUILD_WEB_URL";
+    /**
+     * CircleCI build URL environment variable.
+     */
+    private static final String CIRCLE_BUILD_URL = "CIRCLE_BUILD_URL";
+    /**
+     * Drone build link environment variable.
+     */
+    private static final String DRONE_BUILD_LINK = "DRONE_BUILD_LINK";
 
     /**
      * Get the URI of the current build from the environment variables set on common build systems like GitHub Actions, GitLab CI, etc.
      * @return the URI of the current build or null if it cannot be determined
      */
     public static String getBuildURI() {
-        // GitHub Actions
-        String githubServerUrl = System.getenv("GITHUB_SERVER_URL");
-        String githubRepository = System.getenv("GITHUB_REPOSITORY");
-        String githubRunId = System.getenv("GITHUB_RUN_ID");
-
-        if (!isNullOrBlank(githubServerUrl) && !isNullOrBlank(githubRepository) && !isNullOrBlank(githubRunId)) {
-            return String.format("%s/%s/actions/runs/%s", githubServerUrl, githubRepository, githubRunId);
-        }
-
-        // GitLab CI
-        String ciProjectUrl = System.getenv("CI_PROJECT_URL");
-        String ciJobId = System.getenv("CI_JOB_ID");
-        if (!isNullOrBlank(ciProjectUrl) && !isNullOrBlank(ciJobId)) {
-            return String.format("%s/-/jobs/%s", ciProjectUrl, ciJobId);
-        }
-
-        // Jenkins
-        String buildUrl = System.getenv("BUILD_URL");
-        if (!isNullOrBlank(buildUrl)) {
-            return buildUrl;
-        }
-        //        String jobUrl = System.getenv("JOB_URL");
-        //        if (!isNullOrBlank(jobUrl)) {
-        //            return jobUrl;
-        //        }
-
-        // Travis CI
-        String travisBuildUrl = System.getenv("TRAVIS_BUILD_WEB_URL");
-        if (!isNullOrBlank(travisBuildUrl)) {
-            return travisBuildUrl;
-        }
-        //        String travisJobUrl = System.getenv("TRAVIS_JOB_WEB_URL");
-        //        if (!isNullOrBlank(travisJobUrl)) {
-        //            return travisJobUrl;
-        //        }
-
-        // CircleCI
-        String circleBuildUrl = System.getenv("CIRCLE_BUILD_URL");
-        if (!isNullOrBlank(circleBuildUrl)) {
-            return circleBuildUrl;
-        }
-
-        // Drone by Harness
-        String droneBuildUrl = System.getenv("DRONE_BUILD_LINK");
-        if (!isNullOrBlank(droneBuildUrl)) {
-            return droneBuildUrl;
-        }
-        return null;
-    }
-
-    /**
-     * Get the URI of the current build from the specified pattern and environment variables and pattern. An example
-     * pattern could be "${SERVER}/jobs/${JOB_ID}". The environment variables are specified as a list of names.
-     * @param pattern the pattern to use to build the URI
-     * @return the URI of the current build or null if it cannot be determined
-     */
-    private static String getBuildUriFromPattern(String pattern) {
-        String result = pattern;
-        Pattern regex = Pattern.compile("\\$\\{([^}]+)\\}");
-        Matcher matcher = regex.matcher(pattern);
-
-        while (matcher.find()) {
-            String varName = matcher.group(1);
-            if (isNullOrBlank(varName)) {
-                return null;
-            }
-            String value = System.getenv(varName);
-            if (isNullOrBlank(value)) {
-                return null;
-            }
-            result = result.replace("${" + varName + "}", value);
-        }
-        return result;
+        return Optional.ofNullable(fromGithubActions()).orElseGet(() -> Optional.ofNullable(fromGitlabCI())
+                .orElseGet(() -> Optional.ofNullable(fromEnvironment(JENKINS_BUILD_URL))
+                        .orElseGet(() -> Optional.ofNullable(fromEnvironment(CIRCLE_BUILD_URL))
+                                .orElseGet(() -> Optional.ofNullable(fromEnvironment(TRAVIS_BUILD_WEB_URL))
+                                        .orElseGet(() -> Optional.ofNullable(fromEnvironment(DRONE_BUILD_LINK))
+                                                .orElse(null))))));
     }
 
     /**
@@ -120,10 +70,77 @@ public class EnvironmentUtils {
      * @param str the name of the environment variable or pattern to use
      * @return the URI of the current build or null if it cannot be determined
      */
-    public static String getBuildURI(String str) {
+    public static String getBuildURI(final String str) {
+        if (StringUtils.isBlank(str)) {
+            return null;
+        }
         if (str.contains("${")) {
             return getBuildUriFromPattern(str);
         }
         return System.getenv(str);
+    }
+
+    private static String fromGithubActions() {
+        final String githubServerUrl = System.getenv("GITHUB_SERVER_URL");
+        final String githubRepository = System.getenv("GITHUB_REPOSITORY");
+        final String githubRunId = System.getenv("GITHUB_RUN_ID");
+
+        if (!StringUtils.isBlank(githubServerUrl)
+                && !StringUtils.isBlank(githubRepository)
+                && !StringUtils.isBlank(githubRunId)) {
+            return String.format("%s/%s/actions/runs/%s", githubServerUrl, githubRepository, githubRunId);
+        }
+
+        return null;
+    }
+
+    private static String fromGitlabCI() {
+        final String ciProjectUrl = System.getenv("CI_PROJECT_URL");
+        final String ciJobId = System.getenv("CI_JOB_ID");
+        if (!StringUtils.isBlank(ciProjectUrl) && !StringUtils.isBlank(ciJobId)) {
+            return String.format("%s/-/jobs/%s", ciProjectUrl, ciJobId);
+        }
+        return null;
+    }
+
+    private static String fromEnvironment(String name) {
+        final String url = System.getenv(name);
+        if (!StringUtils.isBlank(url)) {
+            return url;
+        }
+        return null;
+    }
+
+    /**
+     * Get the URI of the current build from the specified pattern and environment variables and pattern. An example
+     * pattern could be "${SERVER}/jobs/${JOB_ID}". The environment variables are specified as a list of names.
+     * @param pattern the pattern to use to build the URI
+     * @return the URI of the current build or null if it cannot be determined
+     */
+    private static String getBuildUriFromPattern(final String pattern) {
+        if (pattern == null) {
+            return null;
+        }
+
+        final StringBuilder result = new StringBuilder(pattern);
+        final Matcher matcher = VARIABLE_PATTERN.matcher(pattern);
+
+        while (matcher.find()) {
+            final String varName = matcher.group(1);
+            if (StringUtils.isBlank(varName)) {
+                return null;
+            }
+
+            final String value = System.getenv(varName);
+            if (StringUtils.isBlank(value)) {
+                return null;
+            }
+
+            final int start = result.indexOf("${" + varName + "}");
+            final int end = start + varName.length() + 3;
+            result.replace(start, end, value);
+        }
+
+        return result.toString();
     }
 }

--- a/src/main/java/org/cyclonedx/gradle/utils/EnvironmentUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/EnvironmentUtils.java
@@ -21,6 +21,7 @@ package org.cyclonedx.gradle.utils;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 /**
@@ -53,7 +54,7 @@ public class EnvironmentUtils {
      * Get the URI of the current build from the environment variables set on common build systems like GitHub Actions, GitLab CI, etc.
      * @return the URI of the current build or null if it cannot be determined
      */
-    public static String getBuildURI() {
+    @Nullable public static String getBuildURI() {
         return Optional.ofNullable(fromGithubActions()).orElseGet(() -> Optional.ofNullable(fromGitlabCI())
                 .orElseGet(() -> Optional.ofNullable(fromEnvironment(JENKINS_BUILD_URL))
                         .orElseGet(() -> Optional.ofNullable(fromEnvironment(CIRCLE_BUILD_URL))
@@ -70,7 +71,7 @@ public class EnvironmentUtils {
      * @param str the name of the environment variable or pattern to use
      * @return the URI of the current build or null if it cannot be determined
      */
-    public static String getBuildURI(final String str) {
+    @Nullable public static String getBuildURI(final String str) {
         if (StringUtils.isBlank(str)) {
             return null;
         }
@@ -80,7 +81,7 @@ public class EnvironmentUtils {
         return System.getenv(str);
     }
 
-    private static String fromGithubActions() {
+    @Nullable private static String fromGithubActions() {
         final String githubServerUrl = System.getenv("GITHUB_SERVER_URL");
         final String githubRepository = System.getenv("GITHUB_REPOSITORY");
         final String githubRunId = System.getenv("GITHUB_RUN_ID");
@@ -94,7 +95,7 @@ public class EnvironmentUtils {
         return null;
     }
 
-    private static String fromGitlabCI() {
+    @Nullable private static String fromGitlabCI() {
         final String ciProjectUrl = System.getenv("CI_PROJECT_URL");
         final String ciJobId = System.getenv("CI_JOB_ID");
         if (!StringUtils.isBlank(ciProjectUrl) && !StringUtils.isBlank(ciJobId)) {
@@ -103,7 +104,7 @@ public class EnvironmentUtils {
         return null;
     }
 
-    private static String fromEnvironment(String name) {
+    @Nullable private static String fromEnvironment(String name) {
         final String url = System.getenv(name);
         if (!StringUtils.isBlank(url)) {
             return url;
@@ -117,7 +118,7 @@ public class EnvironmentUtils {
      * @param pattern the pattern to use to build the URI
      * @return the URI of the current build or null if it cannot be determined
      */
-    private static String getBuildUriFromPattern(final String pattern) {
+    @Nullable private static String getBuildUriFromPattern(final String pattern) {
         if (pattern == null) {
             return null;
         }

--- a/src/test/java/org/cyclonedx/gradle/utils/EnvironmentUtilsTest.java
+++ b/src/test/java/org/cyclonedx/gradle/utils/EnvironmentUtilsTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.utils;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link EnvironmentUtils}. Many of the tests clear the GITHUB_REPOSITORY environment variable to null
+ * because tests normally run on GitHub Actions and if the variable was not cleared for the test - the test would fail.
+ */
+class EnvironmentUtilsTest {
+
+    @Test
+    void getBuildURI_GithubActions() throws Exception {
+        String uri = withEnvironmentVariable("GITHUB_SERVER_URL", "https://github.com")
+                .and("GITHUB_REPOSITORY", "CycloneDX/cyclonedx-gradle-plugin")
+                .and("GITHUB_RUN_ID", "12345")
+                .execute(() -> {
+                    return EnvironmentUtils.getBuildURI();
+                });
+        String expected = "https://github.com/CycloneDX/cyclonedx-gradle-plugin/actions/runs/12345";
+        assertEquals(expected, uri);
+    }
+
+    @Test
+    void getBuildURI_GitlabCI() throws Exception {
+        String uri = withEnvironmentVariable("CI_PROJECT_URL", "https://gitlab.com/project")
+                .and("CI_JOB_ID", "67890")
+                .and("GITHUB_REPOSITORY", null)
+                .execute(() -> {
+                    return EnvironmentUtils.getBuildURI();
+                });
+        String expected = "https://gitlab.com/project/-/jobs/67890";
+        assertEquals(expected, uri);
+    }
+
+    @Test
+    void getBuildURI_Jenkins() throws Exception {
+        String uri = withEnvironmentVariable("BUILD_URL", "https://jenkins.example.com/job/123")
+                .and("GITHUB_REPOSITORY", null)
+                .execute(() -> {
+                    return EnvironmentUtils.getBuildURI();
+                });
+        assertEquals("https://jenkins.example.com/job/123", uri);
+    }
+
+    @Test
+    void getBuildURI_Drone() throws Exception {
+        String uri = withEnvironmentVariable("DRONE_BUILD_LINK", "https://drone.company.com/octocat/hello-world/42")
+                .and("GITHUB_REPOSITORY", null)
+                .execute(() -> {
+                    return EnvironmentUtils.getBuildURI();
+                });
+        assertEquals("https://drone.company.com/octocat/hello-world/42", uri);
+    }
+
+    @Test
+    void getBuildUriFromPattern() throws Exception {
+        String uri = withEnvironmentVariable("SERVER", "https://example.com")
+                .and("JOB_ID", "123456")
+                .and("GITHUB_REPOSITORY", null)
+                .execute(() -> {
+                    return EnvironmentUtils.getBuildURI("${SERVER}/jobs/${JOB_ID}");
+                });
+
+        String expected = "https://example.com/jobs/123456";
+        assertEquals(expected, uri);
+    }
+
+    @Test
+    void getBuildURI_SingleEnvVar() throws Exception {
+        String uri = withEnvironmentVariable("BUILD_PATH", "https://ci.example.com/build/789")
+                .execute(() -> {
+                    return EnvironmentUtils.getBuildURI("BUILD_PATH");
+                });
+        assertEquals("https://ci.example.com/build/789", uri);
+    }
+
+    @Test
+    void getBuildURI_NoEnvVars() throws Exception {
+        String uri = withEnvironmentVariable("GITHUB_REPOSITORY", null).execute(() -> {
+            return EnvironmentUtils.getBuildURI();
+        });
+        assertNull(uri);
+    }
+}

--- a/src/test/java/org/cyclonedx/gradle/utils/EnvironmentUtilsTest.java
+++ b/src/test/java/org/cyclonedx/gradle/utils/EnvironmentUtilsTest.java
@@ -97,6 +97,12 @@ class EnvironmentUtilsTest {
     }
 
     @Test
+    void getBuildURI_Null() throws Exception {
+        String uri = EnvironmentUtils.getBuildURI(null);
+        assertNull(uri);
+    }
+
+    @Test
     void getBuildURI_NoEnvVars() throws Exception {
         String uri = withEnvironmentVariable("GITHUB_REPOSITORY", null).execute(() -> {
             return EnvironmentUtils.getBuildURI();


### PR DESCRIPTION
Allows the gradle plugin to retrieve the build-system URL from the environment variables present in most CI systems. By default, this feature is disabled. However, for those who would like to include this information in the generated bom they can configure:

```groovy
cyclonedxBom {
    includeBuildSystem = true
}
```

This will attempt to retrieve the build job URL from the CI's environment variables for several CI systems (Jenkins, GitHub Actions, Drone, Jenkins, Circle CI, and Travis CI). If not found, the `build-system` meta-data is not populated. If you are using an different CI system not listed, you can configure the feature to use alternative environment variables and even a pattern of multiple environment variables:

```groovy
cyclonedxBom {
    includeBuildSystem = true
    buildSystemEnvironmentVariable = 'MY_CUSTOM_CI_URL'
}
```

Using multiple environment variables can be achieved using the following (note that you must use single quotes to prevent gradle from interpolating the variables):

```groovy
cyclonedxBom {
    includeBuildSystem = true
    buildSystemEnvironmentVariable = '${SERVER}/build/${BUILD_ID}'
}
```