### PR TITLE
build: run one build with multijdk tests

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -9,6 +9,9 @@ on:
       - master
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 # The following concurrency group cancels in-progress jobs or runs on pull_request events only;
 # if github.head_ref is undefined, the concurrency group will fallback to the run ID,
 # which is guaranteed to be both unique and defined for the run.
@@ -19,33 +22,29 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        java-version:
-          - 8
-          - 11
-          - 17
-          - 21
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 
-      - name: Set up JDK ${{ matrix.java-version }}
+      - name: Set up JDK
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "temurin"
-          java-version: "${{ matrix.java-version }}"
+          java-version: |
+            8
+            11
+            17
+            21
           cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4.4.0
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -i
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4.6.2
         with:
-          name: assembled-plugin-jdk_${{ matrix.java-version }}
+          name: assembled-plugin
           path: build/

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -23,19 +23,22 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4.2.2
 
-      - name: Set up JDK 8
+      - name: Set up JDK
         uses: actions/setup-java@v4.7.1
         with:
           distribution: "temurin"
-          java-version: "8"
-          server-id: "github" # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: "${{ github.workspace }}" # location for the settings.xml file
+          java-version: |
+            8
+            11
+            17
+            21
+          cache: "gradle"
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4.4.0
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build -i
 
       - name: Publish to Gradle portal
         run: |-

--- a/.github/workflows/dependency-submission.yaml
+++ b/.github/workflows/dependency-submission.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-java@v4.7.1
         with:
           distribution: 'temurin'
-          java-version: 8
+          java-version: 21
+          cache: "gradle"
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@v4.4.0

--- a/.github/workflows/gradlew-update.yaml
+++ b/.github/workflows/gradlew-update.yaml
@@ -5,6 +5,10 @@ on:
     - cron: '0 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   update:
     runs-on: ubuntu-latest

--- a/src/test/groovy/org/cyclonedx/gradle/DependencyResolutionSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/DependencyResolutionSpec.groovy
@@ -192,7 +192,6 @@ class DependencyResolutionSpec extends Specification {
             .build()
 
         then:
-        println(result.output)
         result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
         File reportDir = new File(testDir, "build/reports")
 
@@ -351,11 +350,10 @@ class DependencyResolutionSpec extends Specification {
         when:
         def result = GradleRunner.create()
             .withProjectDir(testDir)
-            .withArguments("cyclonedxBom", "--debug", "-S", "--configuration-cache")
+            .withArguments("cyclonedxBom", "--info", "-S", "--configuration-cache")
             .withPluginClasspath()
             .build()
         then:
-        println result.output
         result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
         File reportDir = new File(testDir, "build/reports")
 


### PR DESCRIPTION
This prepares build setup for Gradle 9 where running Gradle in Java version lower than 17 will fail. It will allow to upgrade spotless plugin to version 7.
Also it adds workflow permissions to fix CodeQL alerts [one](https://github.com/CycloneDX/cyclonedx-gradle-plugin/security/code-scanning/1) and [two](https://github.com/CycloneDX/cyclonedx-gradle-plugin/security/code-scanning/2). 