### PR TITLE
fix: use provider for component version convention

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxTask.java
@@ -86,7 +86,9 @@ public abstract class CycloneDxTask extends DefaultTask {
         componentName.convention(getProject().getName());
 
         componentVersion = getProject().getObjects().property(String.class);
-        componentVersion.convention(getProject().getVersion().toString());
+        componentVersion.convention(getProject()
+                .getProviders()
+                .provider(() -> getProject().getVersion().toString()));
 
         outputFormat = getProject().getObjects().property(String.class);
         outputFormat.convention("all");


### PR DESCRIPTION
Ensure the project version will be picked up even if the task is realized before the project version is set.