### PR TITLE
feat: deprecate task property setters

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -5,8 +5,6 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
   workflow_dispatch:
 
 permissions:

--- a/README.md
+++ b/README.md
@@ -52,13 +52,10 @@ cyclonedxBom {
     // Specified the type of project being built. Defaults to 'library'
     projectType = "application"
     // Specified the version of the CycloneDX specification to use. Defaults to '1.6'
-    schemaVersion = "1.6"
-    // Boms destination directory. Defaults to 'build/reports'
-    destination = file("build/reports")
-    // The file name for the generated BOMs (before the file format suffix). Defaults to 'bom'
-    outputName = "bom"
-    // The file format generated, can be xml, json or all for generating both. Defaults to 'all'
-    outputFormat = "json"
+    schemaVersion = org.cyclonedx.model.schema.SchemaVersion.VERSION_16
+    // Custom output locations
+    jsonOutput = file("build/reports/sbom/${project.name}-sbom.json")
+    xmlOutput = file("build/reports/sbom/${project.name}-sbom.xml")
     // Include BOM Serial Number. Defaults to 'true'
     includeBomSerialNumber = false
     // Include License Text. Defaults to 'true'
@@ -80,19 +77,18 @@ If you are using the Kotlin DSL, the plugin can be configured as following:
 
 ```kotlin
 tasks.cyclonedxBom {
-    setIncludeConfigs(listOf("runtimeClasspath"))
-    setSkipConfigs(listOf("compileClasspath", "testCompileClasspath"))
-    setSkipProjects(listOf(rootProject.name, "yourTestSubProject"))
-    setProjectType("application")
-    setSchemaVersion("1.6")
-    setDestination(project.file("build/reports"))
-    setOutputName("bom")
-    setOutputFormat("json")
-    setIncludeBomSerialNumber(false)
-    setIncludeLicenseText(true)
-    setIncludeMetadataResolution(true)
-    setComponentVersion("2.0.0")
-    setComponentName("my-component")
+    includeConfigs = listOf("runtimeClasspath")
+    skipConfigs = listOf("compileClasspath", "testCompileClasspath")
+    skipProjects = listOf(rootProject.name, "yourTestSubProject")
+    projectType = "application"
+    schemaVersion = org.cyclonedx.model.schema.SchemaVersion.VERSION_16
+    jsonOutput = file("build/reports/sbom/${project.name}-sbom.json")
+    xmlOutput = file("build/reports/sbom/${project.name}-sbom.xml")
+    includeBomSerialNumber = false
+    includeLicenseText = true
+    includeMetadataResolution = true
+    componentVersion = "2.0.0"
+    componentName = "my-component"
 }
 ```
 
@@ -128,10 +124,9 @@ allprojects{
     skipConfigs = ["compileClasspath", "testCompileClasspath"]
     skipProjects = [rootProject.name, "yourTestSubProject"]
     projectType = "application"
-    schemaVersion = "1.6"
-    destination = file("build/reports")
-    outputName = "bom"
-    outputFormat = "json"
+    schemaVersion = org.cyclonedx.model.schema.SchemaVersion.VERSION_16
+    jsonOutput = file("build/reports/sbom/${project.name}-sbom.json")
+    xmlOutput = file("build/reports/sbom/${project.name}-sbom.xml")
     includeBomSerialNumber = false
     includeLicenseText = true
     componentVersion = "2.0.0"

--- a/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CycloneDxPlugin.java
@@ -18,6 +18,7 @@
  */
 package org.cyclonedx.gradle;
 
+import java.io.File;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 
@@ -31,6 +32,29 @@ public class CycloneDxPlugin implements Plugin<Project> {
         project.getTasks().register("cyclonedxBom", CycloneDxTask.class, (task) -> {
             task.setGroup("Reporting");
             task.setDescription("Generates a CycloneDX compliant Software Bill of Materials (SBOM)");
+
+            task.getJsonOutput().convention(project.getProviders().provider(() -> {
+                if (!task.outputFormat.get().equals("all")
+                        && !task.outputFormat.get().equals("json")) {
+                    return null;
+                }
+                return project.getLayout()
+                        .file(project.getProviders()
+                                .provider(() -> new File(
+                                        task.destination.get(), String.format("%s.json", task.outputName.get()))))
+                        .get();
+            }));
+            task.getXmlOutput().convention(project.getProviders().provider(() -> {
+                if (!task.outputFormat.get().equals("all")
+                        && !task.outputFormat.get().equals("xml")) {
+                    return null;
+                }
+                return project.getLayout()
+                        .file(project.getProviders()
+                                .provider(() -> new File(
+                                        task.destination.get(), String.format("%s.xml", task.outputName.get()))))
+                        .get();
+            }));
         });
     }
 }

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -114,7 +114,13 @@ class SbomBuilder {
             component.setName(task.getComponentName().get());
             component.setVersion(task.getComponentVersion().get());
             addBuildSystemMetaData(component);
-            component.addExternalReference(task.getGitVCS());
+            if (task.getExternalReferences().isEmpty()) {
+                // this to maintain backward compatibility
+                component.addExternalReference(new ExternalReference());
+            } else {
+                task.getExternalReferences().forEach(component::addExternalReference);
+            }
+
             ExternalReferencesUtil.complementByEnvironment(component, logger);
             metadata.setComponent(component);
         } catch (MalformedPackageURLException e) {

--- a/src/main/java/org/cyclonedx/gradle/utils/CycloneDxUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/CycloneDxUtils.java
@@ -82,7 +82,7 @@ public class CycloneDxUtils {
         }
     }
 
-    private static void writeJSONBom(final Version schemaVersion, final Bom bom, final File destination) {
+    public static void writeJSONBom(final Version schemaVersion, final Bom bom, final File destination) {
         final BomJsonGenerator bomGenerator = BomGeneratorFactory.createJson(schemaVersion, bom);
         try {
             final String bomString = bomGenerator.toJsonString();
@@ -94,7 +94,7 @@ public class CycloneDxUtils {
         validateBom(new JsonParser(), schemaVersion, destination);
     }
 
-    private static void writeXmlBom(final Version schemaVersion, final Bom bom, final File destination) {
+    public static void writeXmlBom(final Version schemaVersion, final Bom bom, final File destination) {
 
         final BomXmlGenerator bomGenerator = BomGeneratorFactory.createXml(schemaVersion, bom);
         try {


### PR DESCRIPTION
This change prepares the plugin for version 3 release. 

- It adds deprecation flags to property setters and allows its direct configuration. 
- It adds `jsonOutput` and `xmlOutput` properties
- It changes default types for `schemaVersion` to `Version` and `projectType` to `Component.Type`