### PR TITLE
Fix typo in README-GradlePluginPortal.md regarding resolutionStrategy

### DIFF
--- a/README-GradlePluginPortal.md
+++ b/README-GradlePluginPortal.md
@@ -1,7 +1,7 @@
 # Gradle Plugin Portal publishing
 
 Gradle provides a registry of published plugins that can easily be imported
-into projects without having to modify the pluginManagement resoultionStrategy.
+into projects without having to modify the pluginManagement resolutionStrategy.
 
 Additionally, gradle provides a plugin to facilitate the building of plugins
 that does extra validation checks, and another plugin that simplifies the


### PR DESCRIPTION
Hi, while reading the README-GradlePluginPortal.md documentation, I came across the typo and fixed it.

resoultionStrategy → resolutionStrategy