### PR TITLE
fix: pass correct string representation when adding external references

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/model/SbomMetaData.java
+++ b/src/main/java/org/cyclonedx/gradle/model/SbomMetaData.java
@@ -66,7 +66,7 @@ public class SbomMetaData implements Serializable {
         metaData.setPublisher(component.getPublisher());
         if (component.getExternalReferences() != null) {
             component.getExternalReferences().forEach(reference -> {
-                metaData.addExternalReference(reference.getType().toString(), reference.getUrl());
+                metaData.addExternalReference(reference.getType().getTypeName(), reference.getUrl());
             });
         }
         return metaData;

--- a/src/test/resources/test-repos/local/repository/com/test/componentb/1.0.0/componentb-1.0.0.pom
+++ b/src/test/resources/test-repos/local/repository/com/test/componentb/1.0.0/componentb-1.0.0.pom
@@ -5,5 +5,8 @@
     <groupId>com.test</groupId>
     <artifactId>componentb</artifactId>
     <version>1.0.0</version>
+    <scm>
+        <url>https://test-repos.local.repository.com/test</url>
+    </scm>
 
 </project>


### PR DESCRIPTION
* when adding external reference to output BOM, pass the same string representation (the type name) that will later be used to search the enumeration entry
* add test
  * add dummy scm information to one of the POMs in test local repo

closes #743