### PR TITLE
feat: exclude artifacts from sbom generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ tasks.cyclonedxBom {
 |----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
 | `includeConfigs`                 | `List<String>`            | `[]` (all configurations) | Configurations to include in SBOM generation. Supports regex patterns              |
 | `skipConfigs`                    | `List<String>`            | `[]`                      | Configurations to exclude from SBOM generation. Supports regex patterns            |
+| `excludeArtifacts`               | `List<String>`            | `[]`                      | Artifacts to exclude from SBOM generation. Format `group:name:version`, supports regex patterns |
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
 | `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |
@@ -199,6 +200,7 @@ tasks.cyclonedxBom {
 
 | Property                         | Type                      | Default                   | Description                                                                        |
 |----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
+| `excludeArtifacts`               | `List<String>`            | `[]`                      | Artifacts to exclude from SBOM generation. Format `group:name:version`, supports regex patterns |
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
 | `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ tasks.cyclonedxBom {
 |----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
 | `includeConfigs`                 | `List<String>`            | `[]` (all configurations) | Configurations to include in SBOM generation. Supports regex patterns              |
 | `skipConfigs`                    | `List<String>`            | `[]`                      | Configurations to exclude from SBOM generation. Supports regex patterns            |
-| `excludeArtifacts`               | `List<String>`            | `[]`                      | Artifacts to exclude from SBOM generation. Format `group:name:version`, supports regex patterns |
+| `excludeArtifacts`               | `List<String>`            | `[]`                      | Artifacts to exclude from SBOM generation. Format `group:name:version`, where each part is a full Java regular expression |
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
 | `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |
@@ -200,7 +200,7 @@ tasks.cyclonedxBom {
 
 | Property                         | Type                      | Default                   | Description                                                                        |
 |----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
-| `excludeArtifacts`               | `List<String>`            | `[]`                      | Artifacts to exclude from SBOM generation. Format `group:name:version`, supports regex patterns |
+| `excludeArtifacts`               | `List<String>`            | `[]`                      | Artifacts to exclude from SBOM generation. Format `group:name:version`, where each part is a full Java regular expression |
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
 | `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Groovy.
 | `componentGroup` | `String` | Project group | Group of the document's main component. |
 | `componentName` | `String` | Project name | Name of the document's main component. |
 | `componentVersion` | `String` | Project version | Version of the document's main component. |
+| `excludeArtifacts` | `List<String>` | `[]` | `group:name:version` patterns for artifacts to exclude from the SBOM. `*` matches any sequence of characters within a segment; an omitted trailing segment matches anything. |
 | `projectType` | `Component.Type` | `LIBRARY` | CycloneDX type of the main component. Kotlin requires an enum value such as `Component.Type.APPLICATION`; Groovy also accepts a type name such as `'application'`. |
 | `schemaVersion` | `Version` | `VERSION_16` | CycloneDX schema used for serialization. Set `Version.VERSION_17` to opt in to CycloneDX 1.7. |
 | `includeBomSerialNumber` | `Boolean` | `true` | Add a generated `urn:uuid:` serial number. |

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Groovy.
 | `componentGroup` | `String` | Project group | Group of the document's main component. |
 | `componentName` | `String` | Project name | Name of the document's main component. |
 | `componentVersion` | `String` | Project version | Version of the document's main component. |
-| `excludeArtifacts` | `List<String>` | `[]` | `group:name:version` patterns for artifacts to exclude from the SBOM. `*` matches any sequence of characters within a segment; an omitted trailing segment matches anything. |
+| `excludeArtifacts` | `List<String>` | `[]` | `group:name:version` patterns for artifacts to exclude from the SBOM. Each segment is matched as a full Java regular expression; an omitted trailing segment matches anything. |
 | `projectType` | `Component.Type` | `LIBRARY` | CycloneDX type of the main component. Kotlin requires an enum value such as `Component.Type.APPLICATION`; Groovy also accepts a type name such as `'application'`. |
 | `schemaVersion` | `Version` | `VERSION_16` | CycloneDX schema used for serialization. Set `Version.VERSION_17` to opt in to CycloneDX 1.7. |
 | `includeBomSerialNumber` | `Boolean` | `true` | Add a generated `urn:uuid:` serial number. |

--- a/src/main/java/org/cyclonedx/gradle/BaseCyclonedxTask.java
+++ b/src/main/java/org/cyclonedx/gradle/BaseCyclonedxTask.java
@@ -186,6 +186,15 @@ public abstract class BaseCyclonedxTask extends DefaultTask {
     @Input
     public abstract Property<Boolean> getIncludeLicenseText();
 
+    /**
+     * The list of artifacts to exclude from the BOM.
+     * The format is `group:name:version` where `group`, `name`, and `version` can be regular expressions.
+     *
+     * @return the list of artifacts to exclude
+     */
+    @Input
+    public abstract ListProperty<String> getExcludeArtifacts();
+
     public BaseCyclonedxTask() {
         super();
         getComponentGroup().convention(getProject().getProviders().provider(() -> getProject()
@@ -204,5 +213,7 @@ public abstract class BaseCyclonedxTask extends DefaultTask {
         getOrganizationalEntity().convention(getProject().getObjects().property(OrganizationalEntity.class));
         getLicenseChoice().convention(getProject().getObjects().property(LicenseChoice.class));
         getExternalReferences().convention(getProject().getObjects().listProperty(ExternalReference.class));
+        getExcludeArtifacts()
+                .convention(getProject().getObjects().listProperty(String.class).empty());
     }
 }

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
@@ -29,7 +29,6 @@ import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
 import org.cyclonedx.gradle.model.SbomGraph;
 import org.cyclonedx.gradle.utils.CyclonedxUtils;
-import org.cyclonedx.gradle.utils.DependencyUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.BomReference;
 import org.cyclonedx.model.Component;
@@ -90,8 +89,10 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 // add the sub-project main component to the map
                 // to avoid duplicating the root project component
                 if (exclusions.stream()
-                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(
-                                subProjectBom.getMetadata().getComponent())))) {
+                        .noneMatch(exclusion -> exclusion.matches(
+                                subProjectBom.getMetadata().getComponent().getGroup(),
+                                subProjectBom.getMetadata().getComponent().getName(),
+                                subProjectBom.getMetadata().getComponent().getVersion()))) {
                     LOGGER.info(
                             "{} Adding sub-project component:[{}] {}",
                             LOG_PREFIX,
@@ -107,7 +108,8 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
             }
             for (final Component component : subProjectBom.getComponents()) {
                 if (exclusions.stream()
-                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(component)))) {
+                        .noneMatch(exclusion ->
+                                exclusion.matches(component.getGroup(), component.getName(), component.getVersion()))) {
                     componentsByBomRef.putIfAbsent(component.getBomRef(), component);
                 }
             }

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
@@ -24,10 +24,12 @@ import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.gradle.model.ArtifactExclusion;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
 import org.cyclonedx.gradle.model.SbomGraph;
 import org.cyclonedx.gradle.utils.CyclonedxUtils;
+import org.cyclonedx.gradle.utils.DependencyUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.BomReference;
 import org.cyclonedx.model.Component;
@@ -54,7 +56,9 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
     @TaskAction
     public void aggregate() throws Exception {
         logParameters();
-        final Bom merged = mergeAll(getInputSboms().getFiles());
+        final List<ArtifactExclusion> exclusions =
+                getExcludeArtifacts().get().stream().map(ArtifactExclusion::new).collect(Collectors.toList());
+        final Bom merged = mergeAll(getInputSboms().getFiles(), exclusions);
         LOGGER.info("{} Writing BOM", LOG_PREFIX);
         if (getJsonOutput().isPresent()) {
             CyclonedxUtils.writeJsonBom(
@@ -68,7 +72,7 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
         }
     }
 
-    private Bom mergeAll(final Set<File> files) throws ParseException {
+    private Bom mergeAll(final Set<File> files, final List<ArtifactExclusion> exclusions) throws ParseException {
         LOGGER.info("{} Received files: {}", LOG_PREFIX, files);
         final Bom aggregateBom = getRootProjectBom();
         final Map<String, Component> componentsByBomRef = new TreeMap<>();
@@ -85,20 +89,27 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 // if the root project BOM main component is not the same as the sub-project BOM main component,
                 // add the sub-project main component to the map
                 // to avoid duplicating the root project component
-                LOGGER.info(
-                        "{} Adding sub-project component:[{}] {}",
-                        LOG_PREFIX,
-                        aggregateBom.getMetadata().getComponent().getBomRef(),
-                        subProjectBom.getMetadata().getComponent().getBomRef());
-                componentsByBomRef.putIfAbsent(
-                        subProjectBom.getMetadata().getComponent().getBomRef(),
-                        subProjectBom.getMetadata().getComponent());
+                if (exclusions.stream()
+                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(
+                                subProjectBom.getMetadata().getComponent())))) {
+                    LOGGER.info(
+                            "{} Adding sub-project component:[{}] {}",
+                            LOG_PREFIX,
+                            aggregateBom.getMetadata().getComponent().getBomRef(),
+                            subProjectBom.getMetadata().getComponent().getBomRef());
+                    componentsByBomRef.putIfAbsent(
+                            subProjectBom.getMetadata().getComponent().getBomRef(),
+                            subProjectBom.getMetadata().getComponent());
+                }
             }
             if (subProjectBom.getComponents() == null) {
                 continue; // no components in this BOM
             }
             for (final Component component : subProjectBom.getComponents()) {
-                componentsByBomRef.putIfAbsent(component.getBomRef(), component);
+                if (exclusions.stream()
+                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(component)))) {
+                    componentsByBomRef.putIfAbsent(component.getBomRef(), component);
+                }
             }
             // merge dependencies of all BOMs
             if (subProjectBom.getDependencies() == null) {
@@ -109,18 +120,28 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 if (dependency.getDependencies() == null || bomRef == null) {
                     continue;
                 }
-                dependenciesByBomRef.compute(bomRef, (key, existingDeps) -> {
-                    final List<String> nextLevelDeps = dependency.getDependencies().stream()
-                            .map(BomReference::getRef)
-                            .filter(ref -> !ref.equals(key))
-                            .collect(Collectors.toList());
-                    if (existingDeps == null) {
-                        return new TreeSet<>(nextLevelDeps);
-                    } else {
-                        existingDeps.addAll(nextLevelDeps);
-                        return existingDeps;
-                    }
-                });
+                // Only keep dependency if the ref is not excluded
+                if (componentsByBomRef.containsKey(bomRef)
+                        || aggregateBom.getMetadata().getComponent().getBomRef().equals(bomRef)) {
+                    dependenciesByBomRef.compute(bomRef, (key, existingDeps) -> {
+                        final List<String> nextLevelDeps = dependency.getDependencies().stream()
+                                .map(BomReference::getRef)
+                                .filter(ref -> !ref.equals(key))
+                                .filter(ref -> componentsByBomRef.containsKey(ref)
+                                        || aggregateBom
+                                                .getMetadata()
+                                                .getComponent()
+                                                .getBomRef()
+                                                .equals(ref))
+                                .collect(Collectors.toList());
+                        if (existingDeps == null) {
+                            return new TreeSet<>(nextLevelDeps);
+                        } else {
+                            existingDeps.addAll(nextLevelDeps);
+                            return existingDeps;
+                        }
+                    });
+                }
             }
         }
         aggregateBom.setComponents(new ArrayList<>(componentsByBomRef.values()));

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
@@ -29,7 +29,6 @@ import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
 import org.cyclonedx.gradle.model.SbomGraph;
 import org.cyclonedx.gradle.utils.CyclonedxUtils;
-import org.cyclonedx.gradle.utils.DependencyUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.BomReference;
 import org.cyclonedx.model.Component;
@@ -94,8 +93,10 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 // add the sub-project main component to the map
                 // to avoid duplicating the root project component
                 if (exclusions.stream()
-                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(
-                                subProjectBom.getMetadata().getComponent())))) {
+                        .noneMatch(exclusion -> exclusion.matches(
+                                subProjectBom.getMetadata().getComponent().getGroup(),
+                                subProjectBom.getMetadata().getComponent().getName(),
+                                subProjectBom.getMetadata().getComponent().getVersion()))) {
                     LOGGER.info(
                             "{} Adding sub-project component:[{}] {}",
                             LOG_PREFIX,
@@ -111,7 +112,8 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
             }
             for (final Component component : subProjectBom.getComponents()) {
                 if (exclusions.stream()
-                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(component)))) {
+                        .noneMatch(exclusion ->
+                                exclusion.matches(component.getGroup(), component.getName(), component.getVersion()))) {
                     componentsByBomRef.putIfAbsent(component.getBomRef(), component);
                 }
             }

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
@@ -24,10 +24,12 @@ import java.io.File;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.cyclonedx.exception.ParseException;
+import org.cyclonedx.gradle.model.ArtifactExclusion;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
 import org.cyclonedx.gradle.model.SbomGraph;
 import org.cyclonedx.gradle.utils.CyclonedxUtils;
+import org.cyclonedx.gradle.utils.DependencyUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.BomReference;
 import org.cyclonedx.model.Component;
@@ -55,7 +57,9 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
     @TaskAction
     public void aggregate() throws Exception {
         logParameters();
-        final Bom merged = mergeAll(getInputSboms().getFiles());
+        final List<ArtifactExclusion> exclusions =
+                getExcludeArtifacts().get().stream().map(ArtifactExclusion::new).collect(Collectors.toList());
+        final Bom merged = mergeAll(getInputSboms().getFiles(), exclusions);
         LOGGER.info("{} Writing BOM", LOG_PREFIX);
         if (getJsonOutput().isPresent()) {
             CyclonedxUtils.writeJsonBom(
@@ -69,7 +73,7 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
         }
     }
 
-    private Bom mergeAll(final Set<File> files) throws ParseException {
+    private Bom mergeAll(final Set<File> files, final List<ArtifactExclusion> exclusions) throws ParseException {
         LOGGER.info("{} Received files: {}", LOG_PREFIX, files);
         final Bom aggregateBom = getRootProjectBom();
         final Map<String, Component> componentsByBomRef = new TreeMap<>();
@@ -89,20 +93,27 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 // if the root project BOM main component is not the same as the sub-project BOM main component,
                 // add the sub-project main component to the map
                 // to avoid duplicating the root project component
-                LOGGER.info(
-                        "{} Adding sub-project component:[{}] {}",
-                        LOG_PREFIX,
-                        aggregateBom.getMetadata().getComponent().getBomRef(),
-                        subProjectBom.getMetadata().getComponent().getBomRef());
-                componentsByBomRef.putIfAbsent(
-                        subProjectBom.getMetadata().getComponent().getBomRef(),
-                        subProjectBom.getMetadata().getComponent());
+                if (exclusions.stream()
+                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(
+                                subProjectBom.getMetadata().getComponent())))) {
+                    LOGGER.info(
+                            "{} Adding sub-project component:[{}] {}",
+                            LOG_PREFIX,
+                            aggregateBom.getMetadata().getComponent().getBomRef(),
+                            subProjectBom.getMetadata().getComponent().getBomRef());
+                    componentsByBomRef.putIfAbsent(
+                            subProjectBom.getMetadata().getComponent().getBomRef(),
+                            subProjectBom.getMetadata().getComponent());
+                }
             }
             if (subProjectBom.getComponents() == null) {
                 continue; // no components in this BOM
             }
             for (final Component component : subProjectBom.getComponents()) {
-                componentsByBomRef.putIfAbsent(component.getBomRef(), component);
+                if (exclusions.stream()
+                        .noneMatch(exclusion -> exclusion.matches(DependencyUtils.toComponentIdentifier(component)))) {
+                    componentsByBomRef.putIfAbsent(component.getBomRef(), component);
+                }
             }
             // merge dependencies of all BOMs
             if (subProjectBom.getDependencies() == null) {
@@ -113,18 +124,28 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 if (dependency.getDependencies() == null || bomRef == null) {
                     continue;
                 }
-                dependenciesByBomRef.compute(bomRef, (key, existingDeps) -> {
-                    final List<String> nextLevelDeps = dependency.getDependencies().stream()
-                            .map(BomReference::getRef)
-                            .filter(ref -> !ref.equals(key))
-                            .collect(Collectors.toList());
-                    if (existingDeps == null) {
-                        return new TreeSet<>(nextLevelDeps);
-                    } else {
-                        existingDeps.addAll(nextLevelDeps);
-                        return existingDeps;
-                    }
-                });
+                // Only keep dependency if the ref is not excluded
+                if (componentsByBomRef.containsKey(bomRef)
+                        || aggregateBom.getMetadata().getComponent().getBomRef().equals(bomRef)) {
+                    dependenciesByBomRef.compute(bomRef, (key, existingDeps) -> {
+                        final List<String> nextLevelDeps = dependency.getDependencies().stream()
+                                .map(BomReference::getRef)
+                                .filter(ref -> !ref.equals(key))
+                                .filter(ref -> componentsByBomRef.containsKey(ref)
+                                        || aggregateBom
+                                                .getMetadata()
+                                                .getComponent()
+                                                .getBomRef()
+                                                .equals(ref))
+                                .collect(Collectors.toList());
+                        if (existingDeps == null) {
+                            return new TreeSet<>(nextLevelDeps);
+                        } else {
+                            existingDeps.addAll(nextLevelDeps);
+                            return existingDeps;
+                        }
+                    });
+                }
             }
         }
         aggregateBom.setComponents(new ArrayList<>(componentsByBomRef.values()));

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
@@ -160,18 +160,28 @@ public class CyclonedxPlugin implements Plugin<Project> {
 
     private void registerCyclonedxAggregateBomTask(
             final Project project, final Configuration cyclonedxBomAggregateConfiguration) {
-        project.getTasks().register(cyclonedxAggregateTaskName, CyclonedxAggregateTask.class, task -> {
-            task.dependsOn(getProjectAndSubprojects(project)
-                    .map(p -> p.getTasks().named(cyclonedxDirectTaskName))
-                    .toArray(Object[]::new));
-            final Provider<Directory> aggregateReportDir =
-                    project.getLayout().getBuildDirectory().dir(cyclonedxAggregateReportDir);
-            task.getXmlOutput().convention(aggregateReportDir.get().file("bom.xml"));
-            task.getJsonOutput().convention(aggregateReportDir.get().file("bom.json"));
-            // Wire inputs from configuration files
-            final Provider<ConfigurableFileCollection> files = project.getProviders()
-                    .provider(() -> project.getObjects().fileCollection().from(cyclonedxBomAggregateConfiguration));
-            task.getInputSboms().from(files);
+        final TaskProvider<CyclonedxAggregateTask> aggregateTaskProvider = project.getTasks()
+                .register(cyclonedxAggregateTaskName, CyclonedxAggregateTask.class, task -> {
+                    task.dependsOn(getProjectAndSubprojects(project)
+                        .map(p -> p.getTasks().named(cyclonedxDirectTaskName))
+                        .toArray(Object[]::new));
+                    final Provider<Directory> aggregateReportDir =
+                            project.getLayout().getBuildDirectory().dir(cyclonedxAggregateReportDir);
+                    task.getXmlOutput().convention(aggregateReportDir.get().file("bom.xml"));
+                    task.getJsonOutput().convention(aggregateReportDir.get().file("bom.json"));
+                    // Wire inputs from configuration files
+                    final Provider<ConfigurableFileCollection> files = project.getProviders()
+                            .provider(() ->
+                                    project.getObjects().fileCollection().from(cyclonedxBomAggregateConfiguration));
+                    task.getInputSboms().from(files);
+                });
+
+        getProjectAndSubprojects(project).forEach(p -> {
+            p.getTasks().withType(CyclonedxDirectTask.class).configureEach(directTask -> {
+                directTask
+                        .getExcludeArtifacts()
+                        .addAll(aggregateTaskProvider.flatMap(CyclonedxAggregateTask::getExcludeArtifacts));
+            });
         });
     }
 

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
@@ -119,18 +119,28 @@ public class CyclonedxPlugin implements Plugin<Project> {
 
     private void registerCyclonedxAggregateBomTask(
             final Project project, final Configuration cyclonedxBomAggregateConfiguration) {
-        project.getTasks().register(cyclonedxAggregateTaskName, CyclonedxAggregateTask.class, task -> {
-            task.dependsOn(getProjectAndSubprojects(project)
-                    .map(p -> p.getTasks().named(cyclonedxDirectTaskName))
-                    .toArray(Object[]::new));
-            final Provider<Directory> aggregateReportDir =
-                    project.getLayout().getBuildDirectory().dir(cyclonedxAggregateReportDir);
-            task.getXmlOutput().convention(aggregateReportDir.get().file("bom.xml"));
-            task.getJsonOutput().convention(aggregateReportDir.get().file("bom.json"));
-            // Wire inputs from configuration files
-            final Provider<ConfigurableFileCollection> files = project.getProviders()
-                    .provider(() -> project.getObjects().fileCollection().from(cyclonedxBomAggregateConfiguration));
-            task.getInputSboms().from(files);
+        final TaskProvider<CyclonedxAggregateTask> aggregateTaskProvider = project.getTasks()
+                .register(cyclonedxAggregateTaskName, CyclonedxAggregateTask.class, task -> {
+                    task.dependsOn(getProjectAndSubprojects(project)
+                            .map(p -> p.getTasks().named(cyclonedxDirectTaskName))
+                            .toArray(Object[]::new));
+                    final Provider<Directory> aggregateReportDir =
+                            project.getLayout().getBuildDirectory().dir(cyclonedxAggregateReportDir);
+                    task.getXmlOutput().convention(aggregateReportDir.get().file("bom.xml"));
+                    task.getJsonOutput().convention(aggregateReportDir.get().file("bom.json"));
+                    // Wire inputs from configuration files
+                    final Provider<ConfigurableFileCollection> files = project.getProviders()
+                            .provider(() ->
+                                    project.getObjects().fileCollection().from(cyclonedxBomAggregateConfiguration));
+                    task.getInputSboms().from(files);
+                });
+
+        getProjectAndSubprojects(project).forEach(p -> {
+            p.getTasks().withType(CyclonedxDirectTask.class).configureEach(directTask -> {
+                directTask
+                        .getExcludeArtifacts()
+                        .addAll(aggregateTaskProvider.flatMap(CyclonedxAggregateTask::getExcludeArtifacts));
+            });
         });
     }
 

--- a/src/main/java/org/cyclonedx/gradle/DependencyGraphTraverser.java
+++ b/src/main/java/org/cyclonedx/gradle/DependencyGraphTraverser.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.maven.model.License;
 import org.apache.maven.project.MavenProject;
+import org.cyclonedx.gradle.model.ArtifactExclusion;
 import org.cyclonedx.gradle.model.ConfigurationScope;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
@@ -60,6 +61,7 @@ class DependencyGraphTraverser {
     private final MavenProjectLookup mavenLookup;
     private final boolean includeMetaData;
     private final MavenHelper mavenHelper;
+    private final List<ArtifactExclusion> artifactExclusions;
 
     DependencyGraphTraverser(
             final Map<ComponentIdentifier, File> resolvedArtifacts,
@@ -69,6 +71,9 @@ class DependencyGraphTraverser {
         this.mavenLookup = mavenLookup;
         this.includeMetaData = task.getIncludeMetadataResolution().get();
         this.mavenHelper = new MavenHelper(task.getIncludeLicenseText().get());
+        this.artifactExclusions = task.getExcludeArtifacts().get().stream()
+                .map(ArtifactExclusion::new)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -97,6 +102,9 @@ class DependencyGraphTraverser {
                 projectName);
         while (!queue.isEmpty()) {
             final GraphNode graphNode = queue.poll();
+            if (isExcluded(graphNode.id)) {
+                continue;
+            }
             if (!graph.containsKey(graphNode)) {
                 graph.put(graphNode, new HashSet<>());
                 LOGGER.debug("{} Traversing node with ID {}", LOG_PREFIX, graphNode.id);
@@ -109,6 +117,9 @@ class DependencyGraphTraverser {
                                 ((ResolvedDependencyResult) dep).getSelected();
                         if (graphNode.id.equals(dependencyComponent.getId())) {
                             continue; // Skip self-references
+                        }
+                        if (isExcluded(dependencyComponent.getId())) {
+                            continue;
                         }
                         LOGGER.debug(
                                 "{} Node with ID {} has dependency with ID {}",
@@ -132,6 +143,10 @@ class DependencyGraphTraverser {
         }
 
         return toSbomComponents(graph);
+    }
+
+    private boolean isExcluded(final ComponentIdentifier id) {
+        return artifactExclusions.stream().anyMatch(exclusion -> exclusion.matches(id));
     }
 
     private Map<SbomComponentId, SbomComponent> toSbomComponents(final Map<GraphNode, Set<GraphNode>> graph) {

--- a/src/main/java/org/cyclonedx/gradle/DependencyGraphTraverser.java
+++ b/src/main/java/org/cyclonedx/gradle/DependencyGraphTraverser.java
@@ -66,14 +66,13 @@ class DependencyGraphTraverser {
     DependencyGraphTraverser(
             final Map<ComponentIdentifier, File> resolvedArtifacts,
             final MavenProjectLookup mavenLookup,
-            final CyclonedxDirectTask task) {
+            final CyclonedxDirectTask task,
+            final List<ArtifactExclusion> artifactExclusions) {
         this.resolvedArtifacts = resolvedArtifacts;
         this.mavenLookup = mavenLookup;
         this.includeMetaData = task.getIncludeMetadataResolution().get();
         this.mavenHelper = new MavenHelper(task.getIncludeLicenseText().get());
-        this.artifactExclusions = task.getExcludeArtifacts().get().stream()
-                .map(ArtifactExclusion::new)
-                .collect(Collectors.toList());
+        this.artifactExclusions = artifactExclusions;
     }
 
     /**

--- a/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
@@ -62,6 +62,7 @@ class SbomGraphProvider implements Callable<SbomGraph> {
     private final Iterable<Configuration> buildScriptConfigurations;
     private final CyclonedxDirectTask task;
     private final MavenProjectLookup mavenLookup;
+    private List<ArtifactExclusion> exclusions = new ArrayList<>();
 
     @Nullable private SbomGraph cachedResult;
 
@@ -100,6 +101,10 @@ class SbomGraphProvider implements Callable<SbomGraph> {
         if (cachedResult != null) {
             return cachedResult;
         }
+
+        this.exclusions = task.getExcludeArtifacts().get().stream()
+            .map(ArtifactExclusion::new)
+            .collect(Collectors.toList());
 
         if (projectGroup.get().isEmpty() || projectVersion.get().isEmpty()) {
             LOGGER.warn(
@@ -174,17 +179,14 @@ class SbomGraphProvider implements Callable<SbomGraph> {
     }
 
     private Stream<Map<SbomComponentId, SbomComponent>> traverseProject() {
-        final DependencyGraphTraverser traverser = new DependencyGraphTraverser(getArtifacts(), mavenLookup, task);
+        final DependencyGraphTraverser traverser =
+                new DependencyGraphTraverser(getArtifacts(), mavenLookup, task, exclusions);
         return getInScopeConfigurations()
                 .map(config -> traverser.traverseGraph(
                         config.getIncoming().getResolutionResult().getRoot(), projectName, config.getName()));
     }
 
     private Map<ComponentIdentifier, File> getArtifacts() {
-        final List<ArtifactExclusion> exclusions = task.getExcludeArtifacts().get().stream()
-                .map(ArtifactExclusion::new)
-                .collect(Collectors.toList());
-
         return getInScopeConfigurations()
                 .flatMap(config -> {
                     final ResolvedArtifactResult[] resolvedArtifacts = config.getIncoming()

--- a/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
@@ -25,12 +25,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.cyclonedx.gradle.model.ArtifactExclusion;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
 import org.cyclonedx.gradle.model.SbomGraph;
@@ -179,6 +181,10 @@ class SbomGraphProvider implements Callable<SbomGraph> {
     }
 
     private Map<ComponentIdentifier, File> getArtifacts() {
+        final List<ArtifactExclusion> exclusions = task.getExcludeArtifacts().get().stream()
+                .map(ArtifactExclusion::new)
+                .collect(Collectors.toList());
+
         return getInScopeConfigurations()
                 .flatMap(config -> {
                     final ResolvedArtifactResult[] resolvedArtifacts = config.getIncoming()
@@ -193,6 +199,9 @@ class SbomGraphProvider implements Callable<SbomGraph> {
                             summarize(resolvedArtifacts, v -> v.getId().getDisplayName()));
                     return Arrays.stream(resolvedArtifacts);
                 })
+                .filter(artifact -> exclusions.stream()
+                        .noneMatch(
+                                exclusion -> exclusion.matches(artifact.getId().getComponentIdentifier())))
                 .collect(Collectors.toMap(
                         artifact -> artifact.getId().getComponentIdentifier(),
                         ResolvedArtifactResult::getFile,

--- a/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomGraphProvider.java
@@ -62,6 +62,7 @@ class SbomGraphProvider implements Callable<SbomGraph> {
     private final Iterable<Configuration> buildScriptConfigurations;
     private final CyclonedxDirectTask task;
     private final MavenProjectLookup mavenLookup;
+    private List<ArtifactExclusion> exclusions = new ArrayList<>();
 
     @Nullable private SbomGraph cachedResult;
 
@@ -100,6 +101,10 @@ class SbomGraphProvider implements Callable<SbomGraph> {
         if (cachedResult != null) {
             return cachedResult;
         }
+
+        this.exclusions = task.getExcludeArtifacts().get().stream()
+                .map(ArtifactExclusion::new)
+                .collect(Collectors.toList());
 
         if (projectGroup.get().isEmpty() || projectVersion.get().isEmpty()) {
             LOGGER.warn(
@@ -174,17 +179,14 @@ class SbomGraphProvider implements Callable<SbomGraph> {
     }
 
     private Stream<Map<SbomComponentId, SbomComponent>> traverseProject() {
-        final DependencyGraphTraverser traverser = new DependencyGraphTraverser(getArtifacts(), mavenLookup, task);
+        final DependencyGraphTraverser traverser =
+                new DependencyGraphTraverser(getArtifacts(), mavenLookup, task, exclusions);
         return getInScopeConfigurations()
                 .map(config -> traverser.traverseGraph(
                         config.getIncoming().getResolutionResult().getRoot(), projectName, config.getName()));
     }
 
     private Map<ComponentIdentifier, File> getArtifacts() {
-        final List<ArtifactExclusion> exclusions = task.getExcludeArtifacts().get().stream()
-                .map(ArtifactExclusion::new)
-                .collect(Collectors.toList());
-
         return getInScopeConfigurations()
                 .flatMap(config -> {
                     final ResolvedArtifactResult[] resolvedArtifacts = config.getIncoming()

--- a/src/main/java/org/cyclonedx/gradle/model/ArtifactExclusion.java
+++ b/src/main/java/org/cyclonedx/gradle/model/ArtifactExclusion.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
+
+public class ArtifactExclusion implements Serializable {
+
+    private final Pattern groupPattern;
+    private final Pattern namePattern;
+    private final Pattern versionPattern;
+
+    public ArtifactExclusion(final String exclusion) {
+        final String[] parts = exclusion.split(":");
+        this.groupPattern = Pattern.compile(parts.length > 0 ? parts[0].replace("*", ".*") : ".*");
+        this.namePattern = Pattern.compile(parts.length > 1 ? parts[1].replace("*", ".*") : ".*");
+        this.versionPattern = Pattern.compile(parts.length > 2 ? parts[2].replace("*", ".*") : ".*");
+    }
+
+    public boolean matches(final ComponentIdentifier componentIdentifier) {
+        String group = "";
+        String name = componentIdentifier.getDisplayName();
+        String version = "";
+
+        if (componentIdentifier instanceof ModuleComponentIdentifier) {
+            final ModuleComponentIdentifier moduleComponentIdentifier = (ModuleComponentIdentifier) componentIdentifier;
+            group = moduleComponentIdentifier.getGroup();
+            name = moduleComponentIdentifier.getModule();
+            version = moduleComponentIdentifier.getVersion();
+        }
+
+        return groupPattern.matcher(Objects.toString(group, "")).matches()
+                && namePattern.matcher(Objects.toString(name, "")).matches()
+                && versionPattern.matcher(Objects.toString(version, "")).matches();
+    }
+}

--- a/src/main/java/org/cyclonedx/gradle/model/ArtifactExclusion.java
+++ b/src/main/java/org/cyclonedx/gradle/model/ArtifactExclusion.java
@@ -32,9 +32,19 @@ public class ArtifactExclusion implements Serializable {
 
     public ArtifactExclusion(final String exclusion) {
         final String[] parts = exclusion.split(":");
-        this.groupPattern = Pattern.compile(parts.length > 0 ? parts[0].replace("*", ".*") : ".*");
-        this.namePattern = Pattern.compile(parts.length > 1 ? parts[1].replace("*", ".*") : ".*");
-        this.versionPattern = Pattern.compile(parts.length > 2 ? parts[2].replace("*", ".*") : ".*");
+        this.groupPattern = createPattern(parts.length > 0 ? parts[0] : "*");
+        this.namePattern = createPattern(parts.length > 1 ? parts[1] : "*");
+        this.versionPattern = createPattern(parts.length > 2 ? parts[2] : "*");
+    }
+
+    private Pattern createPattern(final String part) {
+        return Pattern.compile(part);
+    }
+
+    public boolean matches(final String group, final String name, final String version) {
+        return groupPattern.matcher(Objects.toString(group, "")).matches()
+                && namePattern.matcher(Objects.toString(name, "")).matches()
+                && versionPattern.matcher(Objects.toString(version, "")).matches();
     }
 
     public boolean matches(final ComponentIdentifier componentIdentifier) {
@@ -49,8 +59,6 @@ public class ArtifactExclusion implements Serializable {
             version = moduleComponentIdentifier.getVersion();
         }
 
-        return groupPattern.matcher(Objects.toString(group, "")).matches()
-                && namePattern.matcher(Objects.toString(name, "")).matches()
-                && versionPattern.matcher(Objects.toString(version, "")).matches();
+        return matches(group, name, version);
     }
 }

--- a/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
@@ -24,10 +24,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
-import org.cyclonedx.model.Component;
 import org.gradle.api.artifacts.ArtifactView;
-import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
@@ -41,45 +38,6 @@ import java.util.Objects;
 public class DependencyUtils {
 
     private static final String UNSPECIFIED = "unspecified";
-
-    public static ComponentIdentifier toComponentIdentifier(final Component component) {
-        return new ModuleComponentIdentifier() {
-            @Override
-            public String getGroup() {
-                return component.getGroup();
-            }
-
-            @Override
-            public String getModule() {
-                return component.getName();
-            }
-
-            @Override
-            public String getVersion() {
-                return component.getVersion();
-            }
-
-            @Override
-            public ModuleIdentifier getModuleIdentifier() {
-                return new ModuleIdentifier() {
-                    @Override
-                    public String getGroup() {
-                        return component.getGroup();
-                    }
-
-                    @Override
-                    public String getName() {
-                        return component.getName();
-                    }
-                };
-            }
-
-            @Override
-            public String getDisplayName() {
-                return component.getGroup() + ":" + component.getName() + ":" + component.getVersion();
-            }
-        };
-    }
 
     public static Map<SbomComponentId, SbomComponent> mergeGraphs(
             final Map<SbomComponentId, SbomComponent> firstGraph,

--- a/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
@@ -20,23 +20,66 @@ package org.cyclonedx.gradle.utils;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
+import org.cyclonedx.model.Component;
 import org.gradle.api.artifacts.ArtifactView;
+import org.gradle.api.artifacts.ModuleIdentifier;
+import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.jspecify.annotations.Nullable;
 
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
 public class DependencyUtils {
 
     private static final String UNSPECIFIED = "unspecified";
+
+    public static ComponentIdentifier toComponentIdentifier(final Component component) {
+        return new ModuleComponentIdentifier() {
+            @Override
+            public String getGroup() {
+                return component.getGroup();
+            }
+
+            @Override
+            public String getModule() {
+                return component.getName();
+            }
+
+            @Override
+            public String getVersion() {
+                return component.getVersion();
+            }
+
+            @Override
+            public ModuleIdentifier getModuleIdentifier() {
+                return new ModuleIdentifier() {
+                    @Override
+                    public String getGroup() {
+                        return component.getGroup();
+                    }
+
+                    @Override
+                    public String getName() {
+                        return component.getName();
+                    }
+                };
+            }
+
+            @Override
+            public String getDisplayName() {
+                return component.getGroup() + ":" + component.getName() + ":" + component.getVersion();
+            }
+        };
+    }
 
     public static Map<SbomComponentId, SbomComponent> mergeGraphs(
             final Map<SbomComponentId, SbomComponent> firstGraph,

--- a/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/DependencyUtils.java
@@ -20,66 +20,23 @@ package org.cyclonedx.gradle.utils;
 
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
-import org.cyclonedx.model.Component;
 import org.gradle.api.artifacts.ArtifactView;
-import org.gradle.api.artifacts.ModuleIdentifier;
-import org.gradle.api.artifacts.component.ComponentIdentifier;
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier;
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier;
 import org.gradle.api.artifacts.result.ResolvedComponentResult;
 import org.jspecify.annotations.Nullable;
 
-import java.io.File;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
 public class DependencyUtils {
 
     private static final String UNSPECIFIED = "unspecified";
-
-    public static ComponentIdentifier toComponentIdentifier(final Component component) {
-        return new ModuleComponentIdentifier() {
-            @Override
-            public String getGroup() {
-                return component.getGroup();
-            }
-
-            @Override
-            public String getModule() {
-                return component.getName();
-            }
-
-            @Override
-            public String getVersion() {
-                return component.getVersion();
-            }
-
-            @Override
-            public ModuleIdentifier getModuleIdentifier() {
-                return new ModuleIdentifier() {
-                    @Override
-                    public String getGroup() {
-                        return component.getGroup();
-                    }
-
-                    @Override
-                    public String getName() {
-                        return component.getName();
-                    }
-                };
-            }
-
-            @Override
-            public String getDisplayName() {
-                return component.getGroup() + ":" + component.getName() + ":" + component.getVersion();
-            }
-        };
-    }
 
     public static Map<SbomComponentId, SbomComponent> mergeGraphs(
             final Map<SbomComponentId, SbomComponent> firstGraph,

--- a/src/test/groovy/org/cyclonedx/gradle/ArtifactsExclusionSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/ArtifactsExclusionSpec.groovy
@@ -1,0 +1,134 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.cyclonedx.model.Bom
+import org.cyclonedx.model.Component
+import org.gradle.api.JavaVersion
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
+import org.junit.jupiter.api.Assumptions
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@IgnoreIf({ !JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17) })
+@Unroll("java version: #javaVersion")
+class ArtifactsExclusionSpec extends Specification {
+
+    @Unroll
+    def "should exclude artifacts in aggregate BOM when configured on aggregate task"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+
+            subprojects {
+                apply plugin: 'java'
+                repositories {
+                    mavenCentral()
+                }
+            }
+
+            project(':subA') {
+                group = 'com.example'
+                version = '1.0.0'
+                dependencies {
+                    implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                }
+            }
+
+            tasks.cyclonedxBom {
+                excludeArtifacts = ['org.apache.logging.log4j:.*:.*']
+            }
+        """, "include 'subA'")
+        new File(testDir, "subA").mkdirs()
+
+        when:
+        def runner = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments('cyclonedxBom', '--info', '--stacktrace')
+            .withPluginClasspath()
+                def result = runner.build()
+
+                then:        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+        result.task(":subA:cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+
+        File subAJsonBom = new File(testDir, "subA/build/reports/cyclonedx-direct/bom.json")
+        Bom subABom = new ObjectMapper().readValue(subAJsonBom, Bom.class)
+        assert subABom.getComponents().find(c -> c.name == 'log4j-core') == null
+
+        File aggregateJsonBom = new File(testDir, "build/reports/cyclonedx/bom.json")
+        Bom aggregateBom = new ObjectMapper().readValue(aggregateJsonBom, Bom.class)
+        assert aggregateBom.getComponents().find(c -> c.name == 'log4j-core') == null
+    }
+
+    def "should exclude artifacts with regex"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.cyclonedxDirectBom {
+                excludeArtifacts = ['org.apache.logging.log4j:^.*:^.*']
+            }
+            dependencies {
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+            }""", "rootProject.name = 'hello-world'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments(taskName))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":" + taskName).outcome == TaskOutcome.SUCCESS
+        File jsonBom = new File(testDir, reportLocation + "/bom.json")
+        Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
+        Component log4jCore = bom.getComponents().find(c -> c.name == 'log4j-core')
+        Component log4jApi = bom.getComponents().find(c -> c.name == 'log4j-api')
+
+        assert log4jCore == null
+        assert log4jApi == null
+
+        where:
+        taskName             | reportLocation
+        "cyclonedxDirectBom" | "build/reports/cyclonedx-direct"
+        "cyclonedxBom"       | "build/reports/cyclonedx"
+        javaVersion = JavaVersion.current()
+    }
+}

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1296,4 +1296,48 @@ class PluginConfigurationSpec extends Specification {
         taskName = "cyclonedxDirectBom"
         javaVersion = JavaVersion.current()
     }
+
+    def "should exclude artifacts with regex"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.cyclonedxDirectBom {
+                excludeArtifacts = ['org.apache.logging.log4j:.*:.*']
+            }
+            dependencies {
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+            }""", "rootProject.name = 'hello-world'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments(taskName))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":" + taskName).outcome == TaskOutcome.SUCCESS
+        File jsonBom = new File(testDir, reportLocation + "/bom.json")
+        Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
+        Component log4jCore = bom.getComponents().find(c -> c.name == 'log4j-core')
+        Component log4jApi = bom.getComponents().find(c -> c.name == 'log4j-api')
+
+        assert log4jCore == null
+        assert log4jApi == null
+
+        where:
+        taskName             | reportLocation
+        "cyclonedxDirectBom" | "build/reports/cyclonedx-direct"
+        "cyclonedxBom"       | "build/reports/cyclonedx"
+        javaVersion = JavaVersion.current()
+    }
 }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1368,4 +1368,48 @@ class PluginConfigurationSpec extends Specification {
         taskName = "cyclonedxDirectBom"
         javaVersion = JavaVersion.current()
     }
+
+    def "should exclude artifacts with regex"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.cyclonedxDirectBom {
+                excludeArtifacts = ['org.apache.logging.log4j:.*:.*']
+            }
+            dependencies {
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+            }""", "rootProject.name = 'hello-world'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments(taskName))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":" + taskName).outcome == TaskOutcome.SUCCESS
+        File jsonBom = new File(testDir, reportLocation + "/bom.json")
+        Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
+        Component log4jCore = bom.getComponents().find(c -> c.name == 'log4j-core')
+        Component log4jApi = bom.getComponents().find(c -> c.name == 'log4j-api')
+
+        assert log4jCore == null
+        assert log4jApi == null
+
+        where:
+        taskName             | reportLocation
+        "cyclonedxDirectBom" | "build/reports/cyclonedx-direct"
+        "cyclonedxBom"       | "build/reports/cyclonedx"
+        javaVersion = JavaVersion.current()
+    }
 }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1412,4 +1412,46 @@ class PluginConfigurationSpec extends Specification {
         "cyclonedxBom"       | "build/reports/cyclonedx"
         javaVersion = JavaVersion.current()
     }
+
+    def "should exclude artifacts configured only on the aggregate task"() {
+        given: "excludeArtifacts is configured only on cyclonedxBom, not cyclonedxDirectBom"
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.cyclonedxBom {
+                excludeArtifacts = ['org.apache.logging.log4j:.*:.*']
+            }
+            dependencies {
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+            }""", "rootProject.name = 'hello-world'")
+
+        when: "both the direct and the aggregate task are run"
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom", "cyclonedxBom"))
+            .withPluginClasspath()
+            .build()
+
+        then: "the exclusion propagates to the direct task, so both reports omit the excluded components"
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+
+        File directJsonBom = new File(testDir, "build/reports/cyclonedx-direct/bom.json")
+        Bom directBom = new ObjectMapper().readValue(directJsonBom, Bom.class)
+        assert directBom.getComponents().find(c -> c.name == 'log4j-core') == null
+        assert directBom.getComponents().find(c -> c.name == 'log4j-api') == null
+
+        File aggregateJsonBom = new File(testDir, "build/reports/cyclonedx/bom.json")
+        Bom aggregateBom = new ObjectMapper().readValue(aggregateJsonBom, Bom.class)
+        assert aggregateBom.getComponents().find(c -> c.name == 'log4j-core') == null
+        assert aggregateBom.getComponents().find(c -> c.name == 'log4j-api') == null
+    }
 }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1411,4 +1411,48 @@ class PluginConfigurationSpec extends Specification {
         taskName = "cyclonedxDirectBom"
         javaVersion = JavaVersion.current()
     }
+
+    def "should exclude artifacts with regex"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.cyclonedxDirectBom {
+                excludeArtifacts = ['org.apache.logging.log4j:.*:.*']
+            }
+            dependencies {
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+            }""", "rootProject.name = 'hello-world'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments(taskName))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":" + taskName).outcome == TaskOutcome.SUCCESS
+        File jsonBom = new File(testDir, reportLocation + "/bom.json")
+        Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
+        Component log4jCore = bom.getComponents().find(c -> c.name == 'log4j-core')
+        Component log4jApi = bom.getComponents().find(c -> c.name == 'log4j-api')
+
+        assert log4jCore == null
+        assert log4jApi == null
+
+        where:
+        taskName             | reportLocation
+        "cyclonedxDirectBom" | "build/reports/cyclonedx-direct"
+        "cyclonedxBom"       | "build/reports/cyclonedx"
+        javaVersion = JavaVersion.current()
+    }
 }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1455,4 +1455,46 @@ class PluginConfigurationSpec extends Specification {
         "cyclonedxBom"       | "build/reports/cyclonedx"
         javaVersion = JavaVersion.current()
     }
+
+    def "should exclude artifacts configured only on the aggregate task"() {
+        given: "excludeArtifacts is configured only on cyclonedxBom, not cyclonedxDirectBom"
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.cyclonedxBom {
+                excludeArtifacts = ['org.apache.logging.log4j:.*:.*']
+            }
+            dependencies {
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version:'2.15.0'
+                implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version:'2.15.0'
+            }""", "rootProject.name = 'hello-world'")
+
+        when: "both the direct and the aggregate task are run"
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom", "cyclonedxBom"))
+            .withPluginClasspath()
+            .build()
+
+        then: "the exclusion propagates to the direct task, so both reports omit the excluded components"
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        result.task(":cyclonedxBom").outcome == TaskOutcome.SUCCESS
+
+        File directJsonBom = new File(testDir, "build/reports/cyclonedx-direct/bom.json")
+        Bom directBom = new ObjectMapper().readValue(directJsonBom, Bom.class)
+        assert directBom.getComponents().find(c -> c.name == 'log4j-core') == null
+        assert directBom.getComponents().find(c -> c.name == 'log4j-api') == null
+
+        File aggregateJsonBom = new File(testDir, "build/reports/cyclonedx/bom.json")
+        Bom aggregateBom = new ObjectMapper().readValue(aggregateJsonBom, Bom.class)
+        assert aggregateBom.getComponents().find(c -> c.name == 'log4j-core') == null
+        assert aggregateBom.getComponents().find(c -> c.name == 'log4j-api') == null
+    }
 }


### PR DESCRIPTION
closes #643

Added naive implementation by which it could be possible to exclude artifacts from sbom generation.
