### PR TITLE
feat!: require minimum JDK 17

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -31,8 +31,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: |
-            8
-            11
             17
             25
             21

--- a/.github/workflows/ci-publish.yaml
+++ b/.github/workflows/ci-publish.yaml
@@ -29,8 +29,6 @@ jobs:
         with:
           distribution: "temurin"
           java-version: |
-            8
-            11
             17
             25
             21

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Before contributing, please:
 
 ### Prerequisites
 
-- **Java Development Kit (JDK)**: Java 8 or higher
+- **Java Development Kit (JDK)**: Java 17 or higher
 - **Git**: For version control
 - **IDE**: IntelliJ IDEA, Eclipse, or VS Code with Java support
 
@@ -47,8 +47,8 @@ cd cyclonedx-gradle-plugin
 
 This project uses Gradle toolchains to ensure compatibility across different Java versions. The build is configured to:
 
-- **Target Java Version**: Java 8 (for maximum compatibility)
-- **Testing**: Multiple LTS Java versions (8, 11, 17, 21)
+- **Target Java Version**: Java 17
+- **Testing**: Multiple LTS Java versions (17, 21, 25)
 - **Gradle**: Java 21
 
 ### Testing with Multiple Java Versions
@@ -140,7 +140,7 @@ For detailed information about the PalantirJavaFormat style, see:
 
 The project uses GitHub Actions for CI/CD. All pull requests must:
 
-- Pass all tests on multiple Java versions (8, 11, 17, 21)
+- Pass all tests on multiple Java versions (17, 21, 25)
 - Pass Spotless formatting checks
 - Build successfully
 - Every commit must be signed off with `git commit -s` to acknowledge

--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ plugins {
 > aggregates SBOMs from the project and all subprojects in multi-project builds.
 
 > [!IMPORTANT]
-> Although the plugin is compatible with Java versions starting from 8, support of all versions prior to 17 is
-> deprecated it will be removed in future releases.
+> The plugin requires Java 17 or higher.
 
 ## Quick Start
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     errorprone("com.google.errorprone:error_prone_core:2.48.0")
 }
 
-listOf(8, 11, 17, 21, 25).forEach { version ->
+listOf(17, 21, 25).forEach { version ->
     tasks.register<Test>("testJava$version") {
         description = "Runs tests with Java $version"
         group = "verification"
@@ -58,7 +58,7 @@ listOf(8, 11, 17, 21, 25).forEach { version ->
         classpath = sourceSets["test"].runtimeClasspath
         useJUnitPlatform()
         maxParallelForks = (Runtime.getRuntime().availableProcessors() / 2).coerceAtLeast(1)
-        if (version >= 11) {
+        if (version >= 17) {
             jvmArgs = listOf(
                 "--add-opens", "java.base/java.util=ALL-UNNAMED",
                 "--add-opens", "java.base/java.lang=ALL-UNNAMED"
@@ -71,14 +71,14 @@ listOf(8, 11, 17, 21, 25).forEach { version ->
 }
 
 tasks.named("test") {
-    dependsOn("testJava8", "testJava11", "testJava17", "testJava21", "testJava25")
+    dependsOn("testJava17", "testJava21", "testJava25")
     enabled = false // Prevents the default test task from running tests itself
 }
 
 tasks.withType<JavaCompile>().configureEach {
     dependsOn("processResources")
     options.encoding = "UTF-8"
-    options.release = 8
+    options.release = 17
     options.errorprone {
         check("NullAway", CheckSeverity.ERROR)
         check("DefaultCharset", CheckSeverity.ERROR)
@@ -97,10 +97,10 @@ tasks.withType<JavaCompile>().configureEach {
 tasks.withType<GroovyCompile>().configureEach {
     dependsOn("processResources")
     options.encoding = "UTF-8"
-    options.release = 8
+    options.release = 17
     javaLauncher.set(
         javaToolchains.launcherFor {
-            languageVersion.set(JavaLanguageVersion.of(8))
+            languageVersion.set(JavaLanguageVersion.of(17))
         }
     )
 }


### PR DESCRIPTION
BREAKING CHANGE: Drop support for JDK 8 and JDK 11. The minimum required Java version is now 17.

This change is to support the upgrade of the `cyclonedx-core-java` library, which now requires JDK 17.0. See the [discussion](https://github.com/CycloneDX/cyclonedx-core-java/issues/799) and [PR](https://github.com/CycloneDX/cyclonedx-core-java/pull/770).