### PR TITLE
fix: set license and manufacturer for the main component #654

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,20 +197,20 @@ tasks.cyclonedxBom {
 
 #### `cyclonedxBom`
 
-| Property                         | Type                      | Default                   | Description                                                                        |
-|----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
-| `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
-| `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
-| `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |
-| `includeLicenseText`             | `boolean`                 | `false`                   | Include full license text in components                                            |
-| `includeBuildSystem`             | `boolean`                 | `true`                    | Include build system URL from CI environment                                       |
-| `buildSystemEnvironmentVariable` | `String`                  | -                         | Custom environment variable for build system URL                                   |
-| `componentVersion`               | `String`                  | Project version           | Override the main component version                                                |
-| `componentName`                  | `String`                  | Project name              | Override the main component name                                                   |
-| `componentGroup`                 | `String`                  | Project group             | Override the main component group                                                  |
-| `organizationalEntity`           | `OrganizationalEntity`    | -                         | Organizational metadata for the project, including name, URLs, and contacts        |
-| `externalReferences`             | `List<ExternalReference>` | Git remote URL            | External references for the project, such as documentation or issue trackers       |
-| `licenseChoice`                  | `LicenseChoice`           | -                         | License information for the main component                                         |
+| Property                         | Type                      | Default                   | Description                                                                               |
+|----------------------------------|---------------------------|---------------------------|-------------------------------------------------------------------------------------------|
+| `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.)        |
+| `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                           |
+| `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                          |
+| `includeLicenseText`             | `boolean`                 | `false`                   | Include full license text in components                                                   |
+| `includeBuildSystem`             | `boolean`                 | `true`                    | Include build system URL from CI environment                                              |
+| `buildSystemEnvironmentVariable` | `String`                  | -                         | Custom environment variable for build system URL                                          |
+| `componentVersion`               | `String`                  | Project version           | Override the main component version                                                       |
+| `componentName`                  | `String`                  | Project name              | Override the main component name                                                          |
+| `componentGroup`                 | `String`                  | Project group             | Override the main component group                                                         |
+| `organizationalEntity`           | `OrganizationalEntity`    | -                         | Organizational metadata for the project, including name, URLs, and contacts               |
+| `externalReferences`             | `List<ExternalReference>` | Git remote URL            | External references for the project, such as documentation or issue trackers              |
+| `licenseChoice`                  | `LicenseChoice`           | -                         | License information for the main component; this value replaces any auto-detected license |
 
 ### Output Configuration
 

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -115,19 +115,6 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
                     rootComponent.getId().getName(),
                     e);
         }
-        if (task.getLicenseChoice().isPresent()) {
-            metadata.setLicenses(task.getLicenseChoice().get());
-        }
-
-        if (task.getOrganizationalEntity().isPresent()
-                && !new OrganizationalEntity()
-                        .equals(task.getOrganizationalEntity().get())) {
-            if (version.compareTo(Version.VERSION_16) >= 0) {
-                metadata.setManufacturer(task.getOrganizationalEntity().get());
-            } else {
-                metadata.setManufacture(task.getOrganizationalEntity().get());
-            }
-        }
 
         final Properties pluginProperties = readPluginProperties();
         if (!pluginProperties.isEmpty()) {
@@ -163,6 +150,14 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
         addBuildSystemMetaData(component);
         if (task.getExternalReferences().isPresent()) {
             task.getExternalReferences().get().forEach(component::addExternalReference);
+        }
+        if (task.getLicenseChoice().isPresent()) {
+            component.setLicenses(task.getLicenseChoice().get());
+        }
+        if (task.getOrganizationalEntity().isPresent()
+                && !new OrganizationalEntity()
+                        .equals(task.getOrganizationalEntity().get())) {
+            component.setManufacturer(task.getOrganizationalEntity().get());
         }
         ExternalReferencesUtil.complementByEnvironment(component);
         return component;

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -24,15 +24,7 @@ import com.github.packageurl.MalformedPackageURLException;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.UUID;
+import java.util.*;
 import org.cyclonedx.Version;
 import org.cyclonedx.gradle.model.ComponentComparator;
 import org.cyclonedx.gradle.model.DependencyComparator;
@@ -115,18 +107,9 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
                     rootComponent.getId().getName(),
                     e);
         }
-        if (task.getLicenseChoice().isPresent()) {
-            metadata.setLicenses(task.getLicenseChoice().get());
-        }
-
-        if (task.getOrganizationalEntity().isPresent()
-                && !new OrganizationalEntity()
-                        .equals(task.getOrganizationalEntity().get())) {
-            if (version.compareTo(Version.VERSION_16) >= 0) {
-                metadata.setManufacturer(task.getOrganizationalEntity().get());
-            } else {
-                metadata.setManufacture(task.getOrganizationalEntity().get());
-            }
+        final Optional<OrganizationalEntity> configuredManufacturer = configuredManufacturer();
+        if (configuredManufacturer.isPresent() && version.compareTo(Version.VERSION_16) < 0) {
+            metadata.setManufacture(configuredManufacturer.get());
         }
 
         final Properties pluginProperties = readPluginProperties();
@@ -164,8 +147,23 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
         if (task.getExternalReferences().isPresent()) {
             task.getExternalReferences().get().forEach(component::addExternalReference);
         }
+        if (task.getLicenseChoice().isPresent()) {
+            component.setLicenses(task.getLicenseChoice().get());
+        }
+        final Optional<OrganizationalEntity> configuredManufacturer = configuredManufacturer();
+        if (configuredManufacturer.isPresent() && version.compareTo(Version.VERSION_16) >= 0) {
+            component.setManufacturer(configuredManufacturer.get());
+        }
         ExternalReferencesUtil.complementByEnvironment(component);
         return component;
+    }
+
+    private Optional<OrganizationalEntity> configuredManufacturer() {
+        return task.getOrganizationalEntity()
+                .map(oe -> new OrganizationalEntity().equals(oe)
+                        ? Optional.<OrganizationalEntity>empty()
+                        : Optional.of(oe))
+                .getOrElse(Optional.empty());
     }
 
     private void addBuildSystemMetaData(final Component component) {

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -476,7 +476,7 @@ class PluginConfigurationSpec extends Specification {
         File jsonBom = new File(reportDir, "bom.json")
         Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
         //check Manufacture Data
-        OrganizationalEntity manufacturer = bom.getMetadata().getManufacturer()
+        OrganizationalEntity manufacturer = bom.getMetadata().getComponent().getManufacturer()
         assert manufacturer != null
         assert manufacturer.getName() == "Test"
         assert !manufacturer.getUrls().isEmpty()
@@ -487,7 +487,7 @@ class PluginConfigurationSpec extends Specification {
         }).isEmpty()
 
         //check Licenses Data
-        LicenseChoice licenseChoice = bom.getMetadata().getLicenses()
+        LicenseChoice licenseChoice = bom.getMetadata().getComponent().getLicenses()
         assert licenseChoice != null
         assert licenseChoice.getLicenses() != null
         assert !licenseChoice.getLicenses().findAll({
@@ -521,7 +521,7 @@ class PluginConfigurationSpec extends Specification {
         File jsonBom = new File(reportDir, "bom.json")
         Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
         //check Manufacture Data
-        OrganizationalEntity manufacturer = bom.getMetadata().getManufacturer()
+        OrganizationalEntity manufacturer = bom.getMetadata().getComponent().getManufacturer()
         assert manufacturer != null
         assert manufacturer.getName() == "Test"
         assert !manufacturer.getUrls().isEmpty()
@@ -532,7 +532,7 @@ class PluginConfigurationSpec extends Specification {
         }).isEmpty()
 
         //check Licenses Data
-        LicenseChoice licenseChoice = bom.getMetadata().getLicenses()
+        LicenseChoice licenseChoice = bom.getMetadata().getComponent().getLicenses()
         assert licenseChoice != null
         assert licenseChoice.getLicenses() != null
         assert !licenseChoice.getLicenses().findAll({

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -5,6 +5,8 @@ import org.cyclonedx.gradle.utils.CyclonedxUtils
 import org.cyclonedx.model.Bom
 import org.cyclonedx.model.Component
 import org.cyclonedx.model.ExternalReference
+import org.cyclonedx.model.LicenseChoice
+import org.cyclonedx.model.OrganizationalEntity
 import org.cyclonedx.model.Tool
 import org.gradle.api.JavaVersion
 import org.gradle.testkit.runner.GradleRunner
@@ -472,17 +474,26 @@ class PluginConfigurationSpec extends Specification {
         assert reportDir.exists()
         reportDir.listFiles({ File file -> file.isFile() } as FileFilter).length == 2
         File jsonBom = new File(reportDir, "bom.json")
+        Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
         //check Manufacture Data
-        assert jsonBom.text.contains("\"name\" : \"Test\"")
-        assert jsonBom.text.contains("\"url\"")
-        assert jsonBom.text.contains("\"name\" : \"Max_Mustermann\"")
-        assert jsonBom.text.contains("\"email\" : \"max.mustermann@test.org\"")
-        assert jsonBom.text.contains("\"phone\" : \"0000 99999999\"")
+        OrganizationalEntity manufacturer = bom.getMetadata().getManufacturer()
+        assert manufacturer != null
+        assert manufacturer.getName() == "Test"
+        assert !manufacturer.getUrls().isEmpty()
+        assert !manufacturer.getContacts().findAll({
+            it.name == "Max_Mustermann" &&
+                it.email == "max.mustermann@test.org" &&
+                it.phone == "0000 99999999"
+        }).isEmpty()
 
         //check Licenses Data
-        assert jsonBom.text.contains("\"licenses\"")
-        assert jsonBom.text.contains("\"content\" : \"This is a Licenses-Test\"")
-        assert jsonBom.text.contains("\"url\" : \"https://www.test-Url.org/\"")
+        LicenseChoice licenseChoice = bom.getMetadata().getLicenses()
+        assert licenseChoice != null
+        assert licenseChoice.getLicenses() != null
+        assert !licenseChoice.getLicenses().findAll({
+            it.getAttachmentText().getText() == "This is a Licenses-Test" &&
+            it.getUrl() == "https://www.test-Url.org/"
+        }).isEmpty()
 
         where:
         taskName             | reportLocation
@@ -508,17 +519,26 @@ class PluginConfigurationSpec extends Specification {
         assert reportDir.exists()
         reportDir.listFiles({ File file -> file.isFile() } as FileFilter).length == 2
         File jsonBom = new File(reportDir, "bom.json")
+        Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
         //check Manufacture Data
-        assert jsonBom.text.contains("\"name\" : \"Test\"")
-        assert jsonBom.text.contains("\"url\"")
-        assert jsonBom.text.contains("\"name\" : \"Max_Mustermann\"")
-        assert jsonBom.text.contains("\"email\" : \"max.mustermann@test.org\"")
-        assert jsonBom.text.contains("\"phone\" : \"0000 99999999\"")
+        OrganizationalEntity manufacturer = bom.getMetadata().getManufacturer()
+        assert manufacturer != null
+        assert manufacturer.getName() == "Test"
+        assert !manufacturer.getUrls().isEmpty()
+        assert !manufacturer.getContacts().findAll({
+            it.name == "Max_Mustermann" &&
+                it.email == "max.mustermann@test.org" &&
+                it.phone == "0000 99999999"
+        }).isEmpty()
 
         //check Licenses Data
-        assert jsonBom.text.contains("\"licenses\"")
-        assert jsonBom.text.contains("\"content\" : \"This is a Licenses-Test\"")
-        assert jsonBom.text.contains("\"url\" : \"https://www.test-Url.org/\"")
+        LicenseChoice licenseChoice = bom.getMetadata().getLicenses()
+        assert licenseChoice != null
+        assert licenseChoice.getLicenses() != null
+        assert !licenseChoice.getLicenses().findAll({
+            it.getAttachmentText().getText() == "This is a Licenses-Test" &&
+            it.getUrl() == "https://www.test-Url.org/"
+        }).isEmpty()
 
         where:
         taskName             | reportLocation

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -475,8 +475,8 @@ class PluginConfigurationSpec extends Specification {
         reportDir.listFiles({ File file -> file.isFile() } as FileFilter).length == 2
         File jsonBom = new File(reportDir, "bom.json")
         Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
-        //check Manufacture Data
-        OrganizationalEntity manufacturer = bom.getMetadata().getManufacturer()
+        //check main component Manufacturer Data
+        OrganizationalEntity manufacturer = bom.getMetadata().getComponent().getManufacturer()
         assert manufacturer != null
         assert manufacturer.getName() == "Test"
         assert !manufacturer.getUrls().isEmpty()
@@ -486,14 +486,18 @@ class PluginConfigurationSpec extends Specification {
                 it.phone == "0000 99999999"
         }).isEmpty()
 
-        //check Licenses Data
-        LicenseChoice licenseChoice = bom.getMetadata().getLicenses()
+        //check main component Licenses Data
+        LicenseChoice licenseChoice = bom.getMetadata().getComponent().getLicenses()
         assert licenseChoice != null
         assert licenseChoice.getLicenses() != null
         assert !licenseChoice.getLicenses().findAll({
             it.getAttachmentText().getText() == "This is a Licenses-Test" &&
             it.getUrl() == "https://www.test-Url.org/"
         }).isEmpty()
+
+        // check SBOM licenses and manufacturer are empty
+        assert bom.getMetadata().getLicenses() == null
+        assert bom.getMetadata().getManufacturer() == null
 
         where:
         taskName             | reportLocation
@@ -520,8 +524,8 @@ class PluginConfigurationSpec extends Specification {
         reportDir.listFiles({ File file -> file.isFile() } as FileFilter).length == 2
         File jsonBom = new File(reportDir, "bom.json")
         Bom bom = new ObjectMapper().readValue(jsonBom, Bom.class)
-        //check Manufacture Data
-        OrganizationalEntity manufacturer = bom.getMetadata().getManufacturer()
+        //check main component Manufacture Data
+        OrganizationalEntity manufacturer = bom.getMetadata().getComponent().getManufacturer()
         assert manufacturer != null
         assert manufacturer.getName() == "Test"
         assert !manufacturer.getUrls().isEmpty()
@@ -531,14 +535,18 @@ class PluginConfigurationSpec extends Specification {
                 it.phone == "0000 99999999"
         }).isEmpty()
 
-        //check Licenses Data
-        LicenseChoice licenseChoice = bom.getMetadata().getLicenses()
+        //check main component Licenses Data
+        LicenseChoice licenseChoice = bom.getMetadata().getComponent().getLicenses()
         assert licenseChoice != null
         assert licenseChoice.getLicenses() != null
         assert !licenseChoice.getLicenses().findAll({
             it.getAttachmentText().getText() == "This is a Licenses-Test" &&
             it.getUrl() == "https://www.test-Url.org/"
         }).isEmpty()
+
+        // check SBOM licenses and manufacturer are empty
+        assert bom.getMetadata().getLicenses() == null
+        assert bom.getMetadata().getManufacturer() == null
 
         where:
         taskName             | reportLocation

--- a/src/test/groovy/org/cyclonedx/gradle/utils/OrganizationalEntityUtilTest.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/utils/OrganizationalEntityUtilTest.groovy
@@ -163,8 +163,10 @@ class OrganizationalEntityUtilTest extends Specification {
         if (specVersion.compareTo(Version.VERSION_16) >= 0) {
             assert jsonBom.getMetadata().getManufacture() == null
             assert xmlBom.getMetadata().getManufacture() == null
-            assert jsonBom.getMetadata().getManufacturer().getName() == "name"
-            assert xmlBom.getMetadata().getManufacturer().getName() == "name"
+            assert jsonBom.getMetadata().getManufacturer() == null
+            assert xmlBom.getMetadata().getManufacturer() == null
+            assert jsonBom.getMetadata().getComponent().getManufacturer().getName() == "name"
+            assert xmlBom.getMetadata().getComponent().getManufacturer().getName() == "name"
         } else {
             assert jsonBom.getMetadata().getManufacture().getName() == "name"
             assert xmlBom.getMetadata().getManufacture().getName() == "name"


### PR DESCRIPTION
Put license and manufacturer data under `$.metadata.component.licenses` and `$.metadata.component.manufacturer` instead of `$.metadata.licenses` and `$.metadata.manufacturer`. The latter refers to the license and manufacturer of the SBOM itself and not of the main component. The plugin README states that `licenseChoice` is the "License information for the main component".

fixes #654