### PR TITLE
Fix "Cannot mutate" Gradle error when trying to add SBOM output to artifacts

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
@@ -21,6 +21,7 @@ package org.cyclonedx.gradle;
 import com.google.common.collect.ImmutableMap;
 import java.util.stream.Stream;
 import javax.inject.Inject;
+import org.gradle.api.DefaultTask;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -30,6 +31,7 @@ import org.gradle.api.file.Directory;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskProvider;
 
 /**
@@ -104,49 +106,60 @@ public class CyclonedxPlugin implements Plugin<Project> {
                     final TaskProvider<CyclonedxDirectTask> directTask =
                             evaluatedProject.getTasks().named(cyclonedxDirectTaskName, CyclonedxDirectTask.class);
 
-                    // Deferred: only runs when the task is realized (i.e., when CycloneDX is requested)
-                    directTask.configure(task -> {
-                        if (!task.getEnabled()) {
-                            LOGGER.info(
-                                    "{} Project [{}] skipped because direct BOM task [{}] is disabled",
-                                    LOG_PREFIX,
-                                    evaluatedProject.getDisplayName(),
-                                    cyclonedxDirectTaskName);
-                            return;
-                        }
-                        // Wire output files as artifacts on the outgoing configuration
-                        if (task.getXmlOutput().isPresent()) {
-                            evaluatedProject
-                                    .getArtifacts()
-                                    .add(
-                                            cyclonedxDirectConfigurationName,
-                                            task.getXmlOutput().get().getAsFile(),
-                                            a -> a.builtBy(task));
-                        }
-                        if (task.getJsonOutput().isPresent()) {
-                            evaluatedProject
-                                    .getArtifacts()
-                                    .add(
-                                            cyclonedxDirectConfigurationName,
-                                            task.getJsonOutput().get().getAsFile(),
-                                            a -> a.builtBy(task));
-                        }
-                        // Add aggregate dependency only for enabled tasks
-                        project.getDependencies()
+                    // Skip tasks that aren't enabled
+                    if (!filterProvider(project, directTask, DefaultTask::isEnabled)
+                            .isPresent()) {
+                        LOGGER.info(
+                                "{} Project [{}] skipped because direct BOM task [{}] is disabled",
+                                LOG_PREFIX,
+                                evaluatedProject.getDisplayName(),
+                                cyclonedxDirectTaskName);
+                        return;
+                    }
+
+                    if (filterProvider(project, directTask, task -> task.getXmlOutput()
+                                    .isPresent())
+                            .isPresent()) {
+                        evaluatedProject
+                                .getArtifacts()
                                 .add(
-                                        cyclonedxAggregateConfigurationName,
-                                        project.getDependencies()
-                                                .project(ImmutableMap.of(
-                                                        "path",
-                                                        evaluatedProject.getPath(),
-                                                        "configuration",
-                                                        cyclonedxDirectConfigurationName)));
-                    });
+                                        cyclonedxDirectConfigurationName,
+                                        directTask.map(BaseCyclonedxTask::getXmlOutput),
+                                        a -> a.builtBy(directTask));
+                    }
+
+                    if (filterProvider(project, directTask, task -> task.getJsonOutput()
+                                    .isPresent())
+                            .isPresent()) {
+                        evaluatedProject
+                                .getArtifacts()
+                                .add(
+                                        cyclonedxDirectConfigurationName,
+                                        directTask.map(BaseCyclonedxTask::getJsonOutput),
+                                        a -> a.builtBy(directTask));
+                    }
+
+                    // Add aggregate dependency only for enabled tasks
+                    project.getDependencies()
+                            .add(
+                                    cyclonedxAggregateConfigurationName,
+                                    project.getDependencies()
+                                            .project(ImmutableMap.of(
+                                                    "path",
+                                                    evaluatedProject.getPath(),
+                                                    "configuration",
+                                                    cyclonedxDirectConfigurationName)));
                 }));
     }
 
     private static Stream<Project> getProjectAndSubprojects(final Project project) {
         return Stream.concat(Stream.of(project), project.getSubprojects().stream());
+    }
+
+    private static <T> Provider<T> filterProvider(
+            final Project project, final Provider<? extends T> provider, final Spec<? super T> spec) {
+        return provider.flatMap(
+                task -> spec.isSatisfiedBy(task) ? project.provider(() -> task) : project.provider(() -> null));
     }
 
     private void configureProject(final Project project) {

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
@@ -21,17 +21,13 @@ package org.cyclonedx.gradle;
 import com.google.common.collect.ImmutableMap;
 import java.util.stream.Stream;
 import javax.inject.Inject;
-import org.gradle.api.DefaultTask;
-import org.gradle.api.JavaVersion;
-import org.gradle.api.Plugin;
-import org.gradle.api.Project;
+import org.gradle.api.*;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.TaskProvider;
 
 /**
@@ -106,49 +102,50 @@ public class CyclonedxPlugin implements Plugin<Project> {
                     final TaskProvider<CyclonedxDirectTask> directTask =
                             evaluatedProject.getTasks().named(cyclonedxDirectTaskName, CyclonedxDirectTask.class);
 
-                    // Skip tasks that aren't enabled
-                    if (!filterProvider(project, directTask, DefaultTask::isEnabled)
-                            .isPresent()) {
-                        LOGGER.info(
-                                "{} Project [{}] skipped because direct BOM task [{}] is disabled",
-                                LOG_PREFIX,
-                                evaluatedProject.getDisplayName(),
-                                cyclonedxDirectTaskName);
-                        return;
-                    }
+                    evaluatedProject
+                            .getConfigurations()
+                            .named(cyclonedxDirectConfigurationName)
+                            .configure(cyclonedxDirectConfiguration -> {
+                                final CyclonedxDirectTask task = directTask.get();
+                                if (!task.isEnabled()) {
+                                    LOGGER.info(
+                                            "{} Project [{}] skipped because direct BOM task [{}] is disabled",
+                                            LOG_PREFIX,
+                                            evaluatedProject.getDisplayName(),
+                                            cyclonedxDirectTaskName);
+                                    return;
+                                }
+                                if (task.getXmlOutput().isPresent()) {
+                                    cyclonedxDirectConfiguration.outgoing(
+                                            outgoingConfiguration -> outgoingConfiguration.artifact(
+                                                    task.getXmlOutput(),
+                                                    publishArtifact -> publishArtifact.builtBy(directTask)));
+                                }
+                                if (task.getJsonOutput().isPresent()) {
+                                    cyclonedxDirectConfiguration.outgoing(
+                                            outgoingConfiguration -> outgoingConfiguration.artifact(
+                                                    task.getJsonOutput(),
+                                                    publishArtifact -> publishArtifact.builtBy(directTask)));
+                                }
+                            });
 
-                    if (filterProvider(project, directTask, task -> task.getXmlOutput()
-                                    .isPresent())
-                            .isPresent()) {
-                        evaluatedProject
-                                .getArtifacts()
-                                .add(
-                                        cyclonedxDirectConfigurationName,
-                                        directTask.map(BaseCyclonedxTask::getXmlOutput),
-                                        a -> a.builtBy(directTask));
-                    }
-
-                    if (filterProvider(project, directTask, task -> task.getJsonOutput()
-                                    .isPresent())
-                            .isPresent()) {
-                        evaluatedProject
-                                .getArtifacts()
-                                .add(
-                                        cyclonedxDirectConfigurationName,
-                                        directTask.map(BaseCyclonedxTask::getJsonOutput),
-                                        a -> a.builtBy(directTask));
-                    }
-
-                    // Add aggregate dependency only for enabled tasks
-                    project.getDependencies()
-                            .add(
-                                    cyclonedxAggregateConfigurationName,
-                                    project.getDependencies()
-                                            .project(ImmutableMap.of(
-                                                    "path",
-                                                    evaluatedProject.getPath(),
-                                                    "configuration",
-                                                    cyclonedxDirectConfigurationName)));
+                    project.getConfigurations()
+                            .named(cyclonedxAggregateConfigurationName)
+                            .configure(cyclonedxAggregateConfiguration -> {
+                                // Add aggregate dependency only for enabled tasks
+                                final CyclonedxDirectTask task = directTask.get();
+                                if (!task.isEnabled()) {
+                                    return;
+                                }
+                                cyclonedxAggregateConfiguration
+                                        .getDependencies()
+                                        .add(project.getDependencies()
+                                                .project(ImmutableMap.of(
+                                                        "path",
+                                                        evaluatedProject.getPath(),
+                                                        "configuration",
+                                                        cyclonedxDirectConfigurationName)));
+                            });
                 }));
     }
 
@@ -156,18 +153,14 @@ public class CyclonedxPlugin implements Plugin<Project> {
         return Stream.concat(Stream.of(project), project.getSubprojects().stream());
     }
 
-    private static <T> Provider<T> filterProvider(
-            final Project project, final Provider<? extends T> provider, final Spec<? super T> spec) {
-        return provider.flatMap(
-                task -> spec.isSatisfiedBy(task) ? project.provider(() -> task) : project.provider(() -> null));
-    }
-
     private void configureProject(final Project project) {
         // Outgoing configuration to publish SBOMs as artifacts
-        final Configuration cyclonedxBomConfiguration =
-                project.getConfigurations().maybeCreate(cyclonedxDirectConfigurationName);
-        cyclonedxBomConfiguration.setCanBeConsumed(true);
-        cyclonedxBomConfiguration.setCanBeResolved(false);
+        if (!project.getConfigurations().getNames().contains(cyclonedxDirectConfigurationName)) {
+            project.getConfigurations().register(cyclonedxDirectConfigurationName, configuration -> {
+                configuration.setCanBeConsumed(true);
+                configuration.setCanBeResolved(false);
+            });
+        }
         registerCyclonedxDirectBomTask(project);
     }
 

--- a/src/test/groovy/org/cyclonedx/gradle/DependencyResolutionSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/DependencyResolutionSpec.groovy
@@ -594,6 +594,25 @@ class DependencyResolutionSpec extends Specification {
         javaVersion = JavaVersion.current()
     }
 
+    @Issue("https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/821")
+    def "should not fail with 'Cannot mutate' when SBOM is attached to custom artifacts"() {
+        given: "a multi-module project where a subproject attaches SBOM outputs to artifacts"
+        File testDir = TestUtils.duplicate("multi-module-with-maven-publish")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("publish"))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":publish").outcome == TaskOutcome.SUCCESS
+
+        where:
+        javaVersion = JavaVersion.current()
+    }
+
     private static def loadJsonBom(File file) {
         return new JsonSlurper().parse(file)
     }

--- a/src/test/groovy/org/cyclonedx/gradle/DependencyResolutionSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/DependencyResolutionSpec.groovy
@@ -16,6 +16,9 @@ import spock.lang.Issue
 import spock.lang.Specification
 import spock.lang.Unroll
 
+import java.nio.file.Files
+import java.util.zip.ZipFile
+
 @IgnoreIf({ !JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17) })
 @Unroll("java version: #javaVersion")
 class DependencyResolutionSpec extends Specification {
@@ -608,6 +611,10 @@ class DependencyResolutionSpec extends Specification {
 
         then:
         result.task(":publish").outcome == TaskOutcome.SUCCESS
+        def zipFilePath = testDir.toPath().resolve("build/repo/com/example/multi-module-with-maven-publish/1.0.0/multi-module-with-maven-publish-1.0.0.zip")
+        def zipFile = new ZipFile(zipFilePath.toFile())
+        assert !zipFile.getInputStream(zipFile.getEntry("app-a-sbom.json")).text.isEmpty()
+        assert !zipFile.getInputStream(zipFile.getEntry("app-b-sbom.json")).text.isEmpty()
 
         where:
         javaVersion = JavaVersion.current()

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1201,7 +1201,7 @@ class PluginConfigurationSpec extends Specification {
         javaVersion = JavaVersion.current()
     }
 
-    def "should not realize cyclonedx tasks for unrelated builds"() {
+    def "should not run cyclonedx tasks for unrelated builds"() {
         given:
         File testDir = TestUtils.duplicate("multi-module")
 

--- a/src/test/resources/test-projects/multi-module-with-maven-publish/app-a/build.gradle
+++ b/src/test/resources/test-projects/multi-module-with-maven-publish/app-a/build.gradle
@@ -1,0 +1,34 @@
+import org.cyclonedx.gradle.CyclonedxDirectTask
+
+plugins {
+    id 'java-library'
+    id 'org.cyclonedx.bom'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+configurations {
+    sbom {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+dependencies {
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.8.11'
+}
+
+tasks.cyclonedxDirectBom {
+    jsonOutput = layout.buildDirectory.file("cyclonedx/app-a-sbom.json")
+    xmlOutput.unsetConvention()
+}
+
+artifacts {
+    add(configurations.sbom.name, tasks.named("cyclonedxDirectBom", CyclonedxDirectTask).map { it.jsonOutput })
+}

--- a/src/test/resources/test-projects/multi-module-with-maven-publish/app-b/build.gradle
+++ b/src/test/resources/test-projects/multi-module-with-maven-publish/app-b/build.gradle
@@ -1,0 +1,34 @@
+import org.cyclonedx.gradle.CyclonedxDirectTask
+
+plugins {
+    id 'java-library'
+    id 'org.cyclonedx.bom'
+}
+
+configurations {
+    sbom {
+        canBeConsumed = true
+        canBeResolved = false
+    }
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+dependencies {
+    implementation project(':app-a')
+}
+
+tasks.cyclonedxDirectBom {
+    jsonOutput = layout.buildDirectory.file("cyclonedx/app-b-sbom.json")
+    xmlOutput.unsetConvention()
+}
+
+artifacts {
+    add(configurations.sbom.name, tasks.named("cyclonedxDirectBom", CyclonedxDirectTask).map { it.jsonOutput })
+}

--- a/src/test/resources/test-projects/multi-module-with-maven-publish/build.gradle
+++ b/src/test/resources/test-projects/multi-module-with-maven-publish/build.gradle
@@ -1,0 +1,41 @@
+plugins {
+    id 'base'
+    id 'maven-publish'
+}
+
+group = 'com.example'
+version = '1.0.0'
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+}
+
+configurations {
+    sbom {
+        canBeResolved = true
+        canBeConsumed = false
+    }
+}
+
+dependencies {
+    sbom project(path: ':app-a', configuration: 'sbom')
+    sbom project(path: ':app-b', configuration: 'sbom')
+}
+
+def zip = tasks.register("zip", Zip) {
+    from(configurations.sbom)
+}
+
+publishing {
+    publications {
+        register("zip", MavenPublication) {
+            artifact(zip)
+        }
+    }
+    repositories {
+        maven {
+            url = layout.buildDirectory.dir('repo')
+        }
+    }
+}

--- a/src/test/resources/test-projects/multi-module-with-maven-publish/settings.gradle
+++ b/src/test/resources/test-projects/multi-module-with-maven-publish/settings.gradle
@@ -1,0 +1,10 @@
+pluginManagement {
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = 'multi-module-with-maven-publish'
+
+include 'app-a', 'app-b'


### PR DESCRIPTION
Fixes https://github.com/CycloneDX/cyclonedx-gradle-plugin/issues/821.

The problem seems to have been that `configure` was called after the project was evaluated, which caused issues when adding custom artifacts.

To fix this I use `flatMap` and `isPresent` to check if tasks in the sub projects are enabled or if `jsonOutput` or `xmlOutput` is set.
I didn't use the `filter` method available on `Provider` because that is only available in Gradle 8.5+ and still an incubating feature. Additionally I had to use `flatMap` with nested `Provider` because returning `null` directly in the `Transformer` caused a false positive in the NullAway (https://github.com/uber/NullAway/issues/1532) to trigger.
The workaround can me simplified once the bug has been fixed, or removed once Gradle 8.5+ is the minimum supported version

I added a reproducer for the setup in my project that caused the error to happen. I've also tested the fix in my project and it no longer occurs there.