### PR TITLE
fix: publish direct SBOMs lazily

### DIFF
--- a/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxAggregateTask.java
@@ -33,6 +33,7 @@ import org.cyclonedx.model.BomReference;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
 import org.cyclonedx.parsers.BomParserFactory;
+import org.gradle.api.GradleException;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -73,6 +74,9 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
         final Bom aggregateBom = getRootProjectBom();
         final Map<String, Component> componentsByBomRef = new TreeMap<>();
         final Map<String, Set<String>> dependenciesByBomRef = new TreeMap<>();
+
+        checkForMissingInputSboms(files);
+
         for (final File subProjectBomFile : files) {
             final Bom subProjectBom =
                     BomParserFactory.createParser(subProjectBomFile).parse(subProjectBomFile);
@@ -133,6 +137,28 @@ public abstract class CyclonedxAggregateTask extends BaseCyclonedxTask {
                 })
                 .collect(Collectors.toList()));
         return aggregateBom;
+    }
+
+    private void checkForMissingInputSboms(final Set<File> files) {
+        final List<File> missing = new ArrayList<>();
+        for (final File file : files) {
+            if (!file.exists()) {
+                missing.add(file);
+            }
+        }
+        if (!missing.isEmpty()) {
+            StringBuilder message = new StringBuilder();
+            message.append(" The following input SBOMs of task '")
+                    .append(getPath())
+                    .append("' do not exist:\n\n");
+            for (final File file : missing) {
+                message.append("  - ").append(file.getPath()).append("\n");
+            }
+            message.append("\nAn input SBOM is missing when its producing task was skipped at execution time so the"
+                    + " SBOM was never generated. If the omission is intended, disable the producing task using"
+                    + " `enabled = false` to exclude its project from the aggregation.");
+            throw new GradleException(message.toString());
+        }
     }
 
     private Bom getRootProjectBom() {

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxDirectTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxDirectTask.java
@@ -21,13 +21,17 @@ package org.cyclonedx.gradle;
 import static org.cyclonedx.gradle.CyclonedxPlugin.LOG_PREFIX;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomGraph;
 import org.cyclonedx.gradle.utils.CyclonedxUtils;
 import org.cyclonedx.model.Bom;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.provider.ListProperty;
@@ -36,6 +40,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.PathSensitive;
 import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
@@ -154,6 +159,14 @@ public abstract class CyclonedxDirectTask extends BaseCyclonedxTask {
             CyclonedxUtils.writeXmlBom(
                     getSchemaVersion().get(), bom, getXmlOutput().getAsFile().get());
         }
+    }
+
+    @Internal("covered by jsonOutput and xmlOutput")
+    List<RegularFile> getOutputFiles() {
+        return Stream.of(getJsonOutput(), getXmlOutput())
+                .map(Provider::getOrNull)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
     }
 
     private void logParameters() {

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxPlugin.java
@@ -19,12 +19,16 @@
 package org.cyclonedx.gradle;
 
 import com.google.common.collect.ImmutableMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.inject.Inject;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.logging.Logger;
@@ -91,58 +95,13 @@ public class CyclonedxPlugin implements Plugin<Project> {
         // Aggregate task
         registerCyclonedxAggregateBomTask(project, cyclonedxBomAggregateConfiguration);
 
-        getProjectAndSubprojects(project)
-                .forEach(subProject -> subProject.afterEvaluate(evaluatedProject -> {
-                    if (!evaluatedProject.getTasks().getNames().contains(cyclonedxDirectTaskName)) {
-                        LOGGER.info(
-                                "{} Project [{}] skipped because direct BOM task [{}] not found",
-                                LOG_PREFIX,
-                                evaluatedProject.getDisplayName(),
-                                cyclonedxDirectTaskName);
-                        return;
-                    }
-                    final TaskProvider<CyclonedxDirectTask> directTask =
-                            evaluatedProject.getTasks().named(cyclonedxDirectTaskName, CyclonedxDirectTask.class);
-
-                    // Deferred: only runs when the task is realized (i.e., when CycloneDX is requested)
-                    directTask.configure(task -> {
-                        if (!task.getEnabled()) {
-                            LOGGER.info(
-                                    "{} Project [{}] skipped because direct BOM task [{}] is disabled",
-                                    LOG_PREFIX,
-                                    evaluatedProject.getDisplayName(),
-                                    cyclonedxDirectTaskName);
-                            return;
-                        }
-                        // Wire output files as artifacts on the outgoing configuration
-                        if (task.getXmlOutput().isPresent()) {
-                            evaluatedProject
-                                    .getArtifacts()
-                                    .add(
-                                            cyclonedxDirectConfigurationName,
-                                            task.getXmlOutput().get().getAsFile(),
-                                            a -> a.builtBy(task));
-                        }
-                        if (task.getJsonOutput().isPresent()) {
-                            evaluatedProject
-                                    .getArtifacts()
-                                    .add(
-                                            cyclonedxDirectConfigurationName,
-                                            task.getJsonOutput().get().getAsFile(),
-                                            a -> a.builtBy(task));
-                        }
-                        // Add aggregate dependency only for enabled tasks
-                        project.getDependencies()
-                                .add(
-                                        cyclonedxAggregateConfigurationName,
-                                        project.getDependencies()
-                                                .project(ImmutableMap.of(
-                                                        "path",
-                                                        evaluatedProject.getPath(),
-                                                        "configuration",
-                                                        cyclonedxDirectConfigurationName)));
-                    });
-                }));
+        // Deferred: evaluated on resolution of the aggregate configuration, when all direct BOM tasks are configured
+        cyclonedxBomAggregateConfiguration
+                .getDependencies()
+                .addAllLater(project.provider(() -> getProjectAndSubprojects(project)
+                        .filter(this::hasEnabledDirectBomTask)
+                        .map(subProject -> createDirectBomDependency(project.getDependencies(), subProject))
+                        .collect(Collectors.toList())));
     }
 
     private static Stream<Project> getProjectAndSubprojects(final Project project) {
@@ -184,12 +143,45 @@ public class CyclonedxPlugin implements Plugin<Project> {
                     project.getDisplayName());
             return;
         }
-        project.getTasks().register(cyclonedxDirectTaskName, CyclonedxDirectTask.class, task -> {
-            final Provider<Directory> dir =
-                    project.getLayout().getBuildDirectory().dir(cyclonedxDirectReportDir);
-            task.getXmlOutput().convention(dir.get().file("bom.xml"));
-            task.getJsonOutput().convention(dir.get().file("bom.json"));
-            task.getAggregateConfigurationName().convention(cyclonedxAggregateConfigurationName);
-        });
+        final TaskProvider<CyclonedxDirectTask> taskProvider = project.getTasks()
+                .register(cyclonedxDirectTaskName, CyclonedxDirectTask.class, task -> {
+                    final Provider<Directory> dir =
+                            project.getLayout().getBuildDirectory().dir(cyclonedxDirectReportDir);
+                    task.getXmlOutput().convention(dir.get().file("bom.xml"));
+                    task.getJsonOutput().convention(dir.get().file("bom.json"));
+                    task.getAggregateConfigurationName().convention(cyclonedxAggregateConfigurationName);
+                });
+
+        project.getConfigurations()
+                .getByName(cyclonedxDirectConfigurationName)
+                .getOutgoing()
+                .artifacts(taskProvider.map(CyclonedxDirectTask::getOutputFiles), a -> a.builtBy(taskProvider));
+    }
+
+    private boolean hasEnabledDirectBomTask(final Project project) {
+        final Task directBomTask = project.getTasks().findByName(cyclonedxDirectTaskName);
+        if (directBomTask == null) {
+            LOGGER.info(
+                    "{} Project [{}] skipped because direct BOM task [{}] not found",
+                    LOG_PREFIX,
+                    project.getDisplayName(),
+                    cyclonedxDirectTaskName);
+            return false;
+        }
+        if (!directBomTask.getEnabled()) {
+            LOGGER.info(
+                    "{} Project [{}] skipped because direct BOM task [{}] is disabled",
+                    LOG_PREFIX,
+                    project.getDisplayName(),
+                    cyclonedxDirectTaskName);
+            return false;
+        }
+        return true;
+    }
+
+    private Dependency createDirectBomDependency(final DependencyHandler dependencies, final Project directBomProject) {
+        final ImmutableMap<String, String> notation =
+                ImmutableMap.of("path", directBomProject.getPath(), "configuration", cyclonedxDirectConfigurationName);
+        return dependencies.project(notation);
     }
 }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1262,6 +1262,38 @@ class PluginConfigurationSpec extends Specification {
         javaVersion = JavaVersion.current()
     }
 
+    def "aggregate task should fail when an input SBOM was not generated"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            group = 'com.example'
+            version = '1.0.0'
+
+            tasks.named('cyclonedxDirectBom') {
+                onlyIf { false }
+            }
+            """, "rootProject.name = 'missing-sbom'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments(taskName))
+            .withPluginClasspath()
+            .buildAndFail()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SKIPPED
+        result.task(":cyclonedxBom").outcome == TaskOutcome.FAILED
+        result.output.contains("input SBOMs of task ':cyclonedxBom' do not exist")
+
+        where:
+        taskName = "cyclonedxBom"
+        javaVersion = JavaVersion.current()
+    }
+
     def "should resolve dependencies only once per project"() {
         given:
         File testDir = TestUtils.createFromString("""

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -1222,6 +1222,46 @@ class PluginConfigurationSpec extends Specification {
         javaVersion = JavaVersion.current()
     }
 
+    def "should publish direct bom artifacts before outgoing configuration is resolved"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+
+            configurations {
+                resolvedDirectBom {
+                    canBeResolved = true
+                    canBeConsumed = false
+                    extendsFrom cyclonedxDirectBom
+                }
+            }
+
+            tasks.register('resolveDirectBomConfiguration') {
+                doLast {
+                    configurations.resolvedDirectBom.files
+                    tasks.named('cyclonedxDirectBom').get()
+                }
+            }
+            """, "rootProject.name = 'direct-bom-resolution'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments("resolveDirectBomConfiguration", "--stacktrace", "--info", "--parallel")
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":resolveDirectBomConfiguration").outcome == TaskOutcome.SUCCESS
+        result.task(":cyclonedxDirectBom") == null
+
+        where:
+        taskName = "resolveDirectBomConfiguration"
+        javaVersion = JavaVersion.current()
+    }
+
     def "should resolve dependencies only once per project"() {
         given:
         File testDir = TestUtils.createFromString("""

--- a/src/test/groovy/org/cyclonedx/gradle/TestUtils.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/TestUtils.groovy
@@ -99,6 +99,10 @@ class TestUtils {
         arguments.add("--info")
         arguments.add("--configuration-cache")
         arguments.add("--parallel")
+        // Tests rewrite build scripts and immediately start the next build in a reused test-kit daemon.
+        // The daemon's file-system-watching VFS may not have seen the change yet, making the build
+        // falsely reuse the configuration cache. Re-hash from disk instead of trusting the watched VFS.
+        arguments.add("--no-watch-fs")
         return arguments.toArray(new String[0])
     }
 }


### PR DESCRIPTION
This should fix issue #821.

The solution is to replace afterEvaluate with lazy (provider) API. This opens a few minor cans of worms that I could, I believe, successfully close with the help of Claude.

## The fix (commit 1)

- Register the BOM output files as outgoing artifacts at plugin apply time via the task provider (`taskProvider.map(...)`), so they are visible without realizing or running the task.
- Add the aggregate configuration's project dependencies through `DependencySet.addAllLater` with a provider that filters out projects whose direct BOM task is missing or disabled. This preserves the enabled-check of the old `afterEvaluate` block (a disabled subproject stays out of the aggregate and out of the root project's BOM) while keeping the wiring lazy, so unrelated builds still don't realize any CycloneDX tasks.

## Ignoring missing SBOMs

Commit 1 alone will simply skip SBOMs that were not generated, assuming it was due to a disabled task. If the SBOM turns out to not be generated due to an error, we would hide this error (there would be a warning but who reads warnings...). Therefore:

## Proposal: fail on missing input SBOMs (commit 2, separable)

To fix the problem we make `CyclonedxAggregateTask` fail with an explanatory error when an input SBOM is declared but its file was never generated. This can only happen when the producing task was skipped at execution time (e.g. via `onlyIf`), since disabled tasks are already excluded from the configuration. The omission must be made explicit by disabling the producing task. (Previously such files failed the task with an unhelpful `ParseException`.)

This commit is independent of the fix and can be dropped if the behavior change is not wanted.

## Flaky test fix (commit 3)

Diagnosed and fixed by Claude:

> Disable file system watching in functional tests
>
> Tests that rewrite a build script and immediately run the next build in a reused test-kit daemon could see the configuration cache falsely reused, because the daemon's file-system-watching VFS had not yet processed the change. The task under test was then UP-TO-DATE instead of re-running, failing the test. Disabling watching makes the daemon re-hash build scripts from disk at each build start.