### PR TITLE
feat: configurable testConfigs for cdx:maven:package:test

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -31,6 +31,12 @@ The public compatibility surface of produced **Direct SBOMs**, **Aggregate SBOMs
 versioned with the plugin according to [ADR 0004](docs/adr/0004-version-the-sbom-output-contract-with-the-plugin.md).
 _Avoid_: Internal output, report format
 
+**Test Configuration**:
+A Gradle configuration treated as test evidence when labeling a component in a **Direct SBOM**. A component is marked
+test only when every configuration that contributed it is a **Test Configuration**. Classification is by configurable
+name pattern per [ADR 0005](docs/adr/0005-classify-test-configurations-by-name-pattern.md).
+_Avoid_: Test dependency, test scope (unqualified), test source set
+
 ## Flagged ambiguities
 
 - Prefer **SBOM** in explanatory prose. **BOM** remains correct when referring to CycloneDX specification concepts or
@@ -39,6 +45,8 @@ _Avoid_: Internal output, report format
   Qualify the term when the distinction matters.
 - The **SBOM Output Contract** covers parsed CycloneDX meaning, not byte-for-byte serialization. Formatting and ordering
   are not part of the compatibility guarantee when the SBOM remains semantically equivalent.
+- **Test Configuration** is a labeling concern for components already in a **Direct SBOM**. It is distinct from
+  `includeConfigs` / `skipConfigs`, which decide which configurations are scanned into that document.
 
 ## Example dialogue
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ tasks.cyclonedxBom {
 |----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
 | `includeConfigs`                 | `List<String>`            | `[]` (all configurations) | Configurations to include in SBOM generation. Supports regex patterns              |
 | `skipConfigs`                    | `List<String>`            | `[]`                      | Configurations to exclude from SBOM generation. Supports regex patterns            |
+| `testConfigs`                    | `List<String>`            | `['^test.*']`             | Full-match regexes for Test Configurations (`cdx:maven:package:test`). All contributing configs must match; empty = none are test. |
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
 | `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |
@@ -264,6 +265,10 @@ tasks.cyclonedxDirectBom {
 
     // Exclude all test-related configurations using regex
     skipConfigs = [".*test.*", ".*Test.*"]
+
+    // How configuration names are classified for cdx:maven:package:test
+    // Default is ['^test.*']; broaden for custom test source sets (e.g. e2eTest*)
+    testConfigs = ["(?i).*test.*"]
 
     // Set application metadata
     projectType = "application"

--- a/docs/adr/0005-classify-test-configurations-by-name-pattern.md
+++ b/docs/adr/0005-classify-test-configurations-by-name-pattern.md
@@ -1,0 +1,28 @@
+---
+status: accepted
+---
+
+# Classify Test Configurations by name pattern
+
+A component in a Direct SBOM is labeled `cdx:maven:package:test` only when every contributing
+configuration is a Test Configuration. We classify Test Configurations by matching configuration
+names against `testConfigs` (a list of full-match regexes on `CyclonedxDirectTask`), with default
+`['^test.*']` so existing output stays unchanged. We deliberately do not derive Test Configurations
+from Gradle source sets or Test tasks in this change: name patterns match `includeConfigs` /
+`skipConfigs`, stay configuration-cache friendly, and leave richer Gradle-model detection as a
+possible later enhancement. Projects with atypical test configuration names override `testConfigs`.
+
+## Considered Options
+
+- **Name-pattern list (`testConfigs`)** — chosen. Default preserves `startsWith("test")` behavior;
+  override covers custom source sets such as `e2eTest*`.
+- **Derive from source sets / Test tasks** — deferred. More accurate for some builds, but couples
+  labeling to the Project model and is a larger behavior change.
+- **Hard-coded broader default (e.g. `(?i).*test.*`)** — rejected. Would reclassify components under
+  the SBOM Output Contract without an opt-in and likely require a major version (ADR 0004).
+
+## Consequences
+
+- Empty `testConfigs` means no configuration is a Test Configuration (all labeled `test=false`).
+- Aggregate SBOMs keep labels from Contributing Projects' Direct SBOMs; `testConfigs` exists only
+  on `cyclonedxDirectBom`.

--- a/src/main/java/org/cyclonedx/gradle/CyclonedxDirectTask.java
+++ b/src/main/java/org/cyclonedx/gradle/CyclonedxDirectTask.java
@@ -21,6 +21,7 @@ package org.cyclonedx.gradle;
 import static org.cyclonedx.gradle.CyclonedxPlugin.LOG_PREFIX;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -75,6 +76,18 @@ public abstract class CyclonedxDirectTask extends BaseCyclonedxTask {
     public abstract ListProperty<String> getSkipConfigs();
 
     /**
+     * Patterns that identify Test Configurations when labeling components with
+     * {@code cdx:maven:package:test}. A configuration name is a Test Configuration when it fully
+     * matches any pattern ({@link String#matches(String)}). A component is marked test only when
+     * every configuration that contributed it is a Test Configuration. An empty list means no
+     * configuration is treated as a Test Configuration.
+     *
+     * @return the list of regex patterns for Test Configuration names
+     */
+    @Input
+    public abstract ListProperty<String> getTestConfigs();
+
+    /**
      * Whether to include metadata resolution in the BOM. For example, license information.
      * If not set, it defaults to true.
      *
@@ -109,6 +122,7 @@ public abstract class CyclonedxDirectTask extends BaseCyclonedxTask {
     public CyclonedxDirectTask() {
         getIncludeConfigs().convention(new ArrayList<>());
         getSkipConfigs().convention(new ArrayList<>());
+        getTestConfigs().convention(new ArrayList<>(Collections.singletonList("^test.*")));
         getIncludeMetadataResolution().convention(true);
         getIncludeBuildEnvironment().convention(false);
         this.componentsProvider = getProject()
@@ -181,6 +195,7 @@ public abstract class CyclonedxDirectTask extends BaseCyclonedxTask {
                     getIncludeBomSerialNumber().get());
             LOGGER.info("includeConfigs            : {}", getIncludeConfigs().get());
             LOGGER.info("skipConfigs               : {}", getSkipConfigs().get());
+            LOGGER.info("testConfigs               : {}", getTestConfigs().get());
             LOGGER.info(
                     "includeMetadataResolution : {}",
                     getIncludeMetadataResolution().get());

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -280,13 +280,24 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
 
     private Property buildIsTestProperty(final SbomComponent component) {
 
-        boolean isTestComponent = component.getInScopeConfigurations().stream()
-                .allMatch(v -> v.getConfigName().startsWith("test"));
+        boolean isTestComponent =
+                component.getInScopeConfigurations().stream().allMatch(v -> isTestConfiguration(v.getConfigName()));
 
         Property property = new Property();
         property.setName("cdx:maven:package:test");
         property.setValue(Boolean.toString(isTestComponent));
         return property;
+    }
+
+    private boolean isTestConfiguration(final String configName) {
+        return getTestConfigsPatterns().stream().anyMatch(configName::matches);
+    }
+
+    private List<String> getTestConfigsPatterns() {
+        if (task instanceof CyclonedxDirectTask) {
+            return ((CyclonedxDirectTask) task).getTestConfigs().get();
+        }
+        return Collections.singletonList("^test.*");
     }
 
     private List<Hash> calculateHashes(final File artifactFile) {

--- a/src/test/groovy/org/cyclonedx/gradle/TestConfigurationLabelingSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/TestConfigurationLabelingSpec.groovy
@@ -1,0 +1,203 @@
+package org.cyclonedx.gradle
+
+import org.cyclonedx.model.Bom
+import org.cyclonedx.model.Component
+import org.cyclonedx.parsers.JsonParser
+import org.gradle.api.JavaVersion
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+import spock.lang.Unroll
+
+@IgnoreIf({ !JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17) })
+@Unroll("java version: #javaVersion")
+class TestConfigurationLabelingSpec extends Specification {
+
+    def "default testConfigs marks standard test dependencies as test"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
+                testImplementation 'junit:junit:4.13.2'
+            }
+            """, "rootProject.name = 'test-label-default'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom"))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        Bom bom = parseDirectBom(testDir)
+        testProperty(bom, "junit", "junit") == "true"
+        testProperty(bom, "com.fasterxml.jackson.core", "jackson-core") == "false"
+
+        where:
+        javaVersion = JavaVersion.current()
+    }
+
+    def "default testConfigs does not treat e2eTest configurations as test"() {
+        given:
+        File testDir = projectWithE2eTestSourceSet("")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom"))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        Bom bom = parseDirectBom(testDir)
+        testProperty(bom, "junit", "junit") == "false"
+
+        where:
+        javaVersion = JavaVersion.current()
+    }
+
+    def "custom testConfigs marks e2eTest-only dependencies as test"() {
+        given:
+        File testDir = projectWithE2eTestSourceSet("""
+            tasks.cyclonedxDirectBom {
+                testConfigs = ['(?i).*test.*']
+            }
+            """)
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom"))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        Bom bom = parseDirectBom(testDir)
+        testProperty(bom, "junit", "junit") == "true"
+        testProperty(bom, "com.fasterxml.jackson.core", "jackson-core") == "false"
+
+        where:
+        javaVersion = JavaVersion.current()
+    }
+
+    def "dependency in both production and test configs is not marked test"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
+                testImplementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
+            }
+            """, "rootProject.name = 'test-label-mixed'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom"))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        Bom bom = parseDirectBom(testDir)
+        testProperty(bom, "com.fasterxml.jackson.core", "jackson-core") == "false"
+
+        where:
+        javaVersion = JavaVersion.current()
+    }
+
+    def "empty testConfigs marks every component as non-test"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
+                testImplementation 'junit:junit:4.13.2'
+            }
+            tasks.cyclonedxDirectBom {
+                testConfigs = []
+            }
+            """, "rootProject.name = 'test-label-empty'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom"))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+        Bom bom = parseDirectBom(testDir)
+        testProperty(bom, "junit", "junit") == "false"
+        testProperty(bom, "com.fasterxml.jackson.core", "jackson-core") == "false"
+
+        where:
+        javaVersion = JavaVersion.current()
+    }
+
+    private static File projectWithE2eTestSourceSet(String taskConfig) {
+        return TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            sourceSets {
+                e2eTest
+            }
+            dependencies {
+                implementation 'com.fasterxml.jackson.core:jackson-core:2.14.2'
+                e2eTestImplementation 'junit:junit:4.13.2'
+            }
+            ${taskConfig}
+            """, "rootProject.name = 'test-label-e2e'")
+    }
+
+    private static Bom parseDirectBom(File testDir) {
+        File reportDir = new File(testDir, "build/reports/cyclonedx-direct")
+        return new JsonParser().parse(new File(reportDir, "bom.json"))
+    }
+
+    private static String testProperty(Bom bom, String group, String name) {
+        Component component = bom.components.find { it.group == group && it.name == name }
+        assert component != null: "component ${group}:${name} not found in BOM"
+        def property = component.properties?.find { it.name == "cdx:maven:package:test" }
+        assert property != null: "cdx:maven:package:test missing on ${group}:${name}"
+        return property.value
+    }
+}


### PR DESCRIPTION
## Summary
- Add `testConfigs` on `cyclonedxDirectBom` so configuration names can be classified as Test Configurations when setting `cdx:maven:package:test`.
- Default remains `['^test.*']` (equivalent to the previous `startsWith("test")` check), so the SBOM Output Contract is unchanged without an opt-in (ADR 0004 / ADR 0005).
- Projects with custom test source sets (e.g. `e2eTest`) can override with patterns such as `['(?i).*test.*']`.

## Context
Today a component is labeled `cdx:maven:package:test = true` only when every in-scope configuration name starts with the literal `"test"`. That misses custom source sets such as `e2eTest` / `integrationTest`, so test-only tooling can appear as production dependencies in the Direct SBOM.

`includeConfigs` / `skipConfigs` already control which configurations are *scanned*; this change only affects the *label*. Classification stays name-pattern based (not derived from Gradle source sets) — see ADR 0005.

## Test plan
- [x] `./gradlew spotlessApply testJava21 --tests "*TestConfigurationLabelingSpec"`
- [ ] CI matrix on the PR
- [ ] Manual check: default build still marks `testImplementation` deps as test
- [ ] Manual check: `e2eTest` + `testConfigs = ['(?i).*test.*']` marks those deps as test


Made with [Cursor](https://cursor.com)