### PR TITLE
build(deps): bump cyclonedx-core-java from 11.0.1 to 13.0.0

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -45,6 +45,12 @@ _Avoid_: Test dependency, test scope (unqualified), test source set
   Qualify the term when the distinction matters.
 - The **SBOM Output Contract** covers parsed CycloneDX meaning, not byte-for-byte serialization. Formatting and ordering
   are not part of the compatibility guarantee when the SBOM remains semantically equivalent.
+- The **SBOM Output Contract** is conditioned on the JVM executing the build. Evidence that JVM cannot produce, such as
+  an artifact hash whose algorithm no installed security provider offers, is absent rather than fabricated or fatal. Two
+  SBOMs generated from identical inputs on different JVMs may therefore differ, and that difference is not a contract
+  violation.
+- Unqualified **Java 8** can mean the bytecode target of `src/main`, a cell of the test matrix, or the JVM a consumer's
+  Gradle build runs on. Say **build JVM** for the last of these; it is the one the **SBOM Output Contract** depends on.
 - **Test Configuration** is a labeling concern for components already in a **Direct SBOM**. It is distinct from
   `includeConfigs` / `skipConfigs`, which decide which configurations are scanned into that document.
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ tasks.cyclonedxBom {
 | `skipConfigs`                    | `List<String>`            | `[]`                      | Configurations to exclude from SBOM generation. Supports regex patterns            |
 | `testConfigs`                    | `List<String>`            | `['^test.*']`             | Full-match regexes for Test Configurations (`cdx:maven:package:test`). All contributing configs must match; empty = none are test. |
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
-| `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
+| `schemaVersion`                  | `Version`                 | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |
 | `includeLicenseText`             | `boolean`                 | `false`                   | Include full license text in components                                            |
 | `includeMetadataResolution`      | `boolean`                 | `true`                    | Include complete metadata resolution for components                                |
@@ -201,7 +201,7 @@ tasks.cyclonedxBom {
 | Property                         | Type                      | Default                   | Description                                                                        |
 |----------------------------------|---------------------------|---------------------------|------------------------------------------------------------------------------------|
 | `projectType`                    | `Component.Type`          | `"library"`               | Type of project (`"application"`, `"library"`, `"framework"`, `"container"`, etc.) |
-| `schemaVersion`                  | `SchemaVersion`           | `VERSION_16`              | CycloneDX schema version to use                                                    |
+| `schemaVersion`                  | `Version`                 | `VERSION_16`              | CycloneDX schema version to use                                                    |
 | `includeBomSerialNumber`         | `boolean`                 | `true`                    | Include unique BOM serial number                                                   |
 | `includeLicenseText`             | `boolean`                 | `false`                   | Include full license text in components                                            |
 | `includeBuildSystem`             | `boolean`                 | `true`                    | Include build system URL from CI environment                                       |
@@ -276,7 +276,7 @@ tasks.cyclonedxDirectBom {
     componentVersion = "2.0.0-SNAPSHOT"
 
     // Schema configuration
-    schemaVersion = org.cyclonedx.model.schema.SchemaVersion.VERSION_16
+    schemaVersion = org.cyclonedx.Version.VERSION_16
 
     // Metadata options
     includeBomSerialNumber = true
@@ -379,7 +379,7 @@ tasks.cyclonedxDirectBom.enabled = false
 
 ```kotlin
 import org.cyclonedx.model.*
-import org.cyclonedx.model.schema.*
+import org.cyclonedx.Version
 
 plugins {
     id("org.cyclonedx.bom") version "3.3.0"
@@ -389,7 +389,7 @@ plugins {
 tasks.cyclonedxDirectBom {
     // Project configuration
     projectType = "application"
-    schemaVersion = SchemaVersion.VERSION_16
+    schemaVersion = Version.VERSION_16
 
     // Component details
     componentName = "acme-payment-service"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    api("org.cyclonedx:cyclonedx-core-java:11.0.1") {
+    api("org.cyclonedx:cyclonedx-core-java:13.0.0") {
         exclude(group = "org.apache.logging.log4j", module = "log4j-slf4j-impl")
     }
     api("org.jspecify:jspecify:1.0.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
         exclude(module = "groovy-all")
     }
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.13.4")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.13.4")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("com.github.stefanbirkner:system-lambda:1.2.1")
 

--- a/docs/adr/0006-isolate-only-version-branching-from-core-in-the-3x-line.md
+++ b/docs/adr/0006-isolate-only-version-branching-from-core-in-the-3x-line.md
@@ -1,0 +1,27 @@
+---
+status: accepted
+---
+
+# Isolate only version-branching logic from Core in the 3.x line
+
+Upgrading to `cyclonedx-core-java` 13.0.0 (#884) asked us to "prepare the next-major boundary" by isolating Core
+construction behind plugin-owned internal values. We isolated only the places the plugin branches on
+`org.cyclonedx.Version` and the schema-version allow-list behind an internal version type, rather than mirroring
+`OrganizationalEntity`, `LicenseChoice`, and `ExternalReference` as plugin-owned types.
+
+There are three such branches: the manufacturer/manufacture and Tool/ToolInformation thresholds in `SbomBuilder`, and
+the `>= 1.2` extension of the artifact hash algorithm set in `HashUtils` that ADR 0007 moved into the plugin. The third
+arrives with the Core upgrade itself, ahead of the internal version type, so it is written as a direct `Version`
+comparison and folded in when that type lands.
+
+## Consequences
+
+- The five core-backed task properties (`schemaVersion`, `projectType`, `organizationalEntity`, `licenseChoice`,
+  `externalReferences`) stay Core-typed on the public API in the 3.x line; only `SbomBuilder`'s internal branching is
+  isolated.
+- #883 owns building the DSL-facing internal configuration model that normalizes those five properties and maps them
+  to Core at a compatibility boundary; it explicitly excludes mirroring the entire CycloneDX object model. Mirroring
+  `OrganizationalEntity`/`LicenseChoice`/`ExternalReference` now, with no DSL yet consuming the mirror, would be
+  speculative work #883 would likely redo or discard.
+- If a further version-conditional branch on Core types appears before #883 lands, extend the same internal version
+  type rather than introducing a second isolation mechanism.

--- a/docs/adr/0007-declare-the-artifact-hash-algorithm-set-in-the-plugin.md
+++ b/docs/adr/0007-declare-the-artifact-hash-algorithm-set-in-the-plugin.md
@@ -1,0 +1,46 @@
+---
+status: accepted
+---
+
+# Declare the artifact hash algorithm set in the plugin
+
+`cyclonedx-core-java` 12.1.0 rewrote `BomUtils.calculateHashes`. Where 11.0.1 acquired each SHA3 digest inside a
+`catch (Exception | NoSuchMethodError)` annotated "Not available in Java 8", the replacement throws
+`IllegalArgumentException("Algorithm not available: SHA3-256")`. Java 8 ships no SHA3 provider, so on a Java 8 **build
+JVM** every artifact hashed now aborts `cyclonedxDirectBom`. Rather than inherit Core's default algorithm list, the
+plugin passes an explicit list to the three-arg `calculateHashes(File, Version, List<Hash.Algorithm>)` overload
+introduced by that same release, filtering the SHA3 family by a `MessageDigest.getInstance` probe so a Java 8 build
+JVM produces exactly the hash set 11.0.1 produced there.
+
+## Considered options
+
+- **Wait for upstream.** [cyclonedx-core-java#848](https://github.com/CycloneDX/cyclonedx-core-java/issues/848) has
+  been open since 2026-06-12; the report's own framing is "I'm not sure it is worth the effort. Maybe you should just
+  update the docs." Core's POM still sets `maven.compiler.release=8` and its classes are major 52, so upstream
+  declares Java 8 support in its build and contradicts it in its hash path. Blocking a release on that reconciliation
+  was rejected.
+- **Widen the `catch` in `SbomBuilder`.** The exception aborts the whole call, so Java 8 SBOMs would lose *every*
+  hash, not just SHA3 — an **SBOM Output Contract** regression under ADR 0004, and a larger one than the bug.
+- **Bundle a pure-Java SHA3 provider.** Would make output identical across build JVMs, but adds a heavyweight runtime
+  dependency to a plugin whose subject is dependency hygiene, and *adds* hashes to Java 8 output that 11.0.1 never
+  emitted.
+- **Keep inheriting Core's defaults, degrading only on failure.** Rejected because the fallback needs the same
+  explicit list anyway, and because it would let a Core patch bump silently move the **SBOM Output Contract**.
+
+## Consequences
+
+- The algorithm set is now the plugin's declared output, not Core's. A future Core release that adds an algorithm to
+  its defaults will not reach users until the plugin adopts it deliberately — which is what ADR 0004 requires of a
+  change to parsed SBOM meaning.
+- Only the SHA3 family is probed. `MD5`, `SHA-1`, `SHA-256`, `SHA-384` and `SHA-512` are requested unguarded, so a JVM
+  lacking them (FIPS mode) still fails loudly exactly as 11.0.1 did, rather than silently emitting an SBOM whose
+  missing hashes are indistinguishable from ones the schema never asked for.
+- Selecting the list carries a schema-version conditional (`>= 1.2` adds `SHA-384` and `SHA3-384`), making it the
+  third `org.cyclonedx.Version` branch ADR 0006 anticipated. It is written here as a direct comparison and folded into
+  the internal `SchemaVersion` type when that type lands, per ADR 0006's own rule.
+- Because the list is plugin-owned, it needs a plugin-owned test. The selection is exposed through a seam taking an
+  availability predicate so the degraded path is provable on any JVM, instead of relying on `GradleVersionsSpec` under
+  `testJava8` — a signal that only fires in a full-matrix run and reports Core's error rather than the plugin's intent.
+- Writing that test surfaced that `junit-jupiter-engine` was absent from the test runtime classpath, so no plain JUnit 5
+  test under `src/test/java` had ever been discovered. Adding the engine was a prerequisite for this guard to run at
+  all, and incidentally activated `DependencyUtilsTest` and `EnvironmentUtilsTest`, which pass.

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -42,6 +42,7 @@ import org.cyclonedx.gradle.model.SbomGraph;
 import org.cyclonedx.gradle.utils.DependencyUtils;
 import org.cyclonedx.gradle.utils.EnvironmentUtils;
 import org.cyclonedx.gradle.utils.ExternalReferencesUtil;
+import org.cyclonedx.gradle.utils.HashUtils;
 import org.cyclonedx.model.Bom;
 import org.cyclonedx.model.Component;
 import org.cyclonedx.model.Dependency;
@@ -66,6 +67,7 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
 
     private static final Logger LOGGER = Logging.getLogger(SbomBuilder.class);
     private final Map<File, List<Hash>> artifactHashes;
+    private final List<Hash.Algorithm> hashAlgorithms;
     private final MavenHelper mavenHelper;
     private final Version version;
     private final T task;
@@ -73,6 +75,7 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
     SbomBuilder(final T task) {
         this.version = task.getSchemaVersion().get();
         this.artifactHashes = new HashMap<>();
+        this.hashAlgorithms = HashUtils.selectAlgorithms(this.version);
         this.mavenHelper = new MavenHelper(task.getIncludeLicenseText().get());
         this.task = task;
     }
@@ -303,7 +306,7 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
     private List<Hash> calculateHashes(final File artifactFile) {
         return artifactHashes.computeIfAbsent(artifactFile, f -> {
             try {
-                return BomUtils.calculateHashes(f, version);
+                return BomUtils.calculateHashes(f, version, hashAlgorithms);
             } catch (IOException e) {
                 LOGGER.error("{} Error encountered calculating hashes", LOG_PREFIX, e);
             }

--- a/src/main/java/org/cyclonedx/gradle/utils/HashUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/HashUtils.java
@@ -1,0 +1,112 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.utils;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+import org.cyclonedx.Version;
+import org.cyclonedx.model.Hash;
+
+/**
+ * Selects the artifact hash algorithms a Direct SBOM carries.
+ *
+ * <p>The set is declared here rather than inherited from {@code BomUtils.calculateHashes(File, Version)} so that a
+ * cyclonedx-core-java upgrade cannot silently move the SBOM Output Contract. See ADR 0007.
+ *
+ * <p>The SHA3 family is filtered by availability because Java 8 ships no SHA3 provider. Core 12.1.0 replaced the
+ * defensive acquisition that used to skip those algorithms with one that throws, which aborts SBOM generation outright
+ * on a Java 8 build JVM. Only SHA3 is filtered: the remaining algorithms are requested unguarded, so a build JVM that
+ * cannot provide them still fails loudly instead of emitting an SBOM whose missing hashes are indistinguishable from
+ * ones the schema never asked for.
+ */
+public class HashUtils {
+
+    /**
+     * Algorithms carried at every schema version.
+     */
+    private static final List<Hash.Algorithm> BASE_ALGORITHMS = Collections.unmodifiableList(Arrays.asList(
+            Hash.Algorithm.MD5,
+            Hash.Algorithm.SHA1,
+            Hash.Algorithm.SHA_256,
+            Hash.Algorithm.SHA_512,
+            Hash.Algorithm.SHA3_256,
+            Hash.Algorithm.SHA3_512));
+
+    /**
+     * Algorithms carried in addition from schema version 1.2 onwards.
+     */
+    private static final List<Hash.Algorithm> EXTENDED_ALGORITHMS =
+            Collections.unmodifiableList(Arrays.asList(Hash.Algorithm.SHA_384, Hash.Algorithm.SHA3_384));
+
+    /**
+     * Selects the algorithms available to this build JVM for the given schema version.
+     *
+     * @param schemaVersion the CycloneDX schema version the SBOM is generated against
+     *
+     * @return the algorithms to request hashes for, in the order they are computed
+     */
+    public static List<Hash.Algorithm> selectAlgorithms(final Version schemaVersion) {
+        return selectAlgorithms(schemaVersion, HashUtils::isAvailable);
+    }
+
+    /**
+     * Selects the algorithms for the given schema version, testing SHA3 availability with the supplied predicate.
+     *
+     * @param schemaVersion the CycloneDX schema version the SBOM is generated against
+     * @param available tests whether this build JVM can provide an algorithm
+     *
+     * @return the algorithms to request hashes for, in the order they are computed
+     */
+    static List<Hash.Algorithm> selectAlgorithms(
+            final Version schemaVersion, final Predicate<Hash.Algorithm> available) {
+
+        final List<Hash.Algorithm> candidates = new ArrayList<>(BASE_ALGORITHMS);
+        if (schemaVersion.getVersion() >= 1.2) {
+            candidates.addAll(EXTENDED_ALGORITHMS);
+        }
+
+        final List<Hash.Algorithm> selected = new ArrayList<>(candidates.size());
+        for (final Hash.Algorithm candidate : candidates) {
+            if (!isSha3(candidate) || available.test(candidate)) {
+                selected.add(candidate);
+            }
+        }
+        return selected;
+    }
+
+    private static boolean isSha3(final Hash.Algorithm algorithm) {
+        return algorithm == Hash.Algorithm.SHA3_256
+                || algorithm == Hash.Algorithm.SHA3_384
+                || algorithm == Hash.Algorithm.SHA3_512;
+    }
+
+    private static boolean isAvailable(final Hash.Algorithm algorithm) {
+        try {
+            MessageDigest.getInstance(algorithm.getSpec());
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+}

--- a/src/test/java/org/cyclonedx/gradle/utils/HashUtilsTest.java
+++ b/src/test/java/org/cyclonedx/gradle/utils/HashUtilsTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import org.cyclonedx.Version;
+import org.cyclonedx.model.Hash;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link HashUtils}. The SHA3 predicate is injected rather than probed so the degraded selection a Java 8
+ * build JVM produces is provable on any JVM, instead of only surfacing under {@code testJava8}.
+ */
+class HashUtilsTest {
+
+    private static boolean allAvailable(final Hash.Algorithm algorithm) {
+        return true;
+    }
+
+    private static boolean noSha3(final Hash.Algorithm algorithm) {
+        return false;
+    }
+
+    @Test
+    void selectsEightAlgorithmsFrom12Onwards() {
+        assertEquals(
+                Arrays.asList(
+                        Hash.Algorithm.MD5,
+                        Hash.Algorithm.SHA1,
+                        Hash.Algorithm.SHA_256,
+                        Hash.Algorithm.SHA_512,
+                        Hash.Algorithm.SHA3_256,
+                        Hash.Algorithm.SHA3_512,
+                        Hash.Algorithm.SHA_384,
+                        Hash.Algorithm.SHA3_384),
+                HashUtils.selectAlgorithms(Version.VERSION_16, HashUtilsTest::allAvailable));
+    }
+
+    @Test
+    void omitsExtendedAlgorithmsBelow12() {
+        assertEquals(
+                Arrays.asList(
+                        Hash.Algorithm.MD5,
+                        Hash.Algorithm.SHA1,
+                        Hash.Algorithm.SHA_256,
+                        Hash.Algorithm.SHA_512,
+                        Hash.Algorithm.SHA3_256,
+                        Hash.Algorithm.SHA3_512),
+                HashUtils.selectAlgorithms(Version.VERSION_11, HashUtilsTest::allAvailable));
+    }
+
+    /**
+     * The Java 8 case: no SHA3 provider, so those algorithms are dropped rather than aborting SBOM generation.
+     */
+    @Test
+    void dropsSha3WhenUnavailableFrom12Onwards() {
+        assertEquals(
+                Arrays.asList(
+                        Hash.Algorithm.MD5,
+                        Hash.Algorithm.SHA1,
+                        Hash.Algorithm.SHA_256,
+                        Hash.Algorithm.SHA_512,
+                        Hash.Algorithm.SHA_384),
+                HashUtils.selectAlgorithms(Version.VERSION_16, HashUtilsTest::noSha3));
+    }
+
+    @Test
+    void dropsSha3WhenUnavailableBelow12() {
+        assertEquals(
+                Arrays.asList(Hash.Algorithm.MD5, Hash.Algorithm.SHA1, Hash.Algorithm.SHA_256, Hash.Algorithm.SHA_512),
+                HashUtils.selectAlgorithms(Version.VERSION_11, HashUtilsTest::noSha3));
+    }
+
+    /**
+     * Only SHA3 is filtered. A build JVM missing MD5 or SHA-1, such as one in FIPS mode, still fails loudly in Core
+     * rather than silently emitting an SBOM without them.
+     */
+    @Test
+    void neverFiltersNonSha3Algorithms() {
+        final List<Hash.Algorithm> selected = HashUtils.selectAlgorithms(Version.VERSION_16, HashUtilsTest::noSha3);
+        assertTrue(selected.contains(Hash.Algorithm.MD5));
+        assertTrue(selected.contains(Hash.Algorithm.SHA1));
+        assertTrue(selected.contains(Hash.Algorithm.SHA_256));
+        assertTrue(selected.contains(Hash.Algorithm.SHA_384));
+        assertTrue(selected.contains(Hash.Algorithm.SHA_512));
+    }
+
+    /**
+     * Core rejects an algorithm requested below the schema version its {@code VersionFilter} allows, so no selection
+     * may contain SHA3-384 before 1.2.
+     */
+    @Test
+    void neverSelectsVersionFilteredAlgorithmsTooEarly() {
+        for (final Version version : Version.values()) {
+            final List<Hash.Algorithm> selected = HashUtils.selectAlgorithms(version, HashUtilsTest::allAvailable);
+            if (version.getVersion() < 1.2) {
+                assertFalse(selected.contains(Hash.Algorithm.SHA3_384), version.getVersionString());
+                assertFalse(selected.contains(Hash.Algorithm.SHA_384), version.getVersionString());
+            } else {
+                assertTrue(selected.contains(Hash.Algorithm.SHA3_384), version.getVersionString());
+                assertTrue(selected.contains(Hash.Algorithm.SHA_384), version.getVersionString());
+            }
+        }
+    }
+
+    /**
+     * The production probe must agree with the JVM actually running this test, at every schema version.
+     */
+    @Test
+    void probesRealAvailability() {
+        final boolean sha3Supported = sha3Supported();
+        for (final Version version : Version.values()) {
+            assertEquals(
+                    sha3Supported,
+                    HashUtils.selectAlgorithms(version).contains(Hash.Algorithm.SHA3_256),
+                    version.getVersionString());
+        }
+    }
+
+    private static boolean sha3Supported() {
+        try {
+            MessageDigest.getInstance("SHA3-256");
+            return true;
+        } catch (NoSuchAlgorithmException e) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 1 of 4 for #884 (upgrade `cyclonedx-core-java` to 13.0.0 without breaking 3.x users). This PR is the foundation the other three stack on top of.

- Bumps the `api` dependency on `org.cyclonedx:cyclonedx-core-java` from `11.0.1` to exactly `13.0.0` (ordinary version string, no strict constraint/range).
- Fixes `README.md`'s four references to a type that has never existed in Core, `org.cyclonedx.model.schema.SchemaVersion` — the real type is `org.cyclonedx.Version` (see `BaseCyclonedxTask#getSchemaVersion`, `Property<Version>`). Those Kotlin example snippets and the property-reference tables would not have compiled as written.

## Why this is safe

Diffed Core's actual source between the `cyclonedx-core-java-11.0.1` and `cyclonedx-core-java-13.0.0` tags for every class this plugin touches (`Version`, `Metadata`, `LicenseChoice`, `OrganizationalEntity`, `Tool`, `ToolInformation`, `Component`, `ExternalReference`, `BomUtils`). The only changes relevant to this plugin's usage are:
- **Additive**: new `Version.VERSION_17` enum constant, new `Metadata.distributionConstraints` field, new `ExternalReference.properties` field.
- **Deprecated but fully present**: `Component.setAuthor`/`getAuthor`, `LicenseChoice.getLicenses`/`setLicenses`/`getExpression`/`setExpression` still work exactly as before (Core keeps them for source compatibility), and the CycloneDX 1.6/1.7 JSON schema still accepts the deprecated fields.

Nothing this plugin's `src/main` calls was removed or had its signature changed, so **no `src/main` behavior changes** — `SbomBuilder`'s tool-identity `component.setAuthor(...)` call is deliberately left untouched to avoid changing the parsed SBOM shape.

## Verification

- `./gradlew spotlessCheck` — clean
- `./gradlew compileJava compileTestJava compileGroovy` — zero errors/warnings (NullAway + errorprone)
- `./gradlew testJava21` — full suite green, including `OrganizationalEntityUtilTest`, `CacheInvalidationSpec`, `CycloneDxSpec`, `PluginConfigurationSpec`
- Confirmed `cyclonedx-core-java:13.0.0` actually resolves via `./gradlew dependencies --configuration compileClasspath`

## Stack

- **PR1 (this PR)**: Core 13.0.0 bump + doc fix → `master`
- PR2: opt-in `Version.VERSION_17` support → based on this PR
- PR3: narrow internal Core-version isolation refactor (ADR 0005) → based on PR2
- PR4: binary-compatibility consumer fixture against published 3.3.0 → based on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: Java 8 regression found and fixed

CI was red on `testJava8` — 11 `GradleVersionsSpec` failures, `java.security.NoSuchAlgorithmException: SHA3-256 MessageDigest not available`. Not a test artifact: it breaks SBOM generation for any user on a Java 8 build JVM.

**Cause.** Core **12.1.0** (not 13.0.0) rewrote `BomUtils.calculateHashes`. Where 11.0.1 acquired each SHA3 digest inside `catch (Exception | NoSuchMethodError) { /* Not available in Java 8 */ }`, the replacement throws `IllegalArgumentException`. Java 8 ships no SHA3 provider (JEP 287 landed it in 9), and `SbomBuilder` catches only `IOException`, so the first artifact hashed aborts `cyclonedxDirectBom`. Upstream tracks it as [cyclonedx-core-java#848](https://github.com/CycloneDX/cyclonedx-core-java/issues/848), open since June and leaning toward documenting rather than fixing — while Core's POM still declares `maven.compiler.release=8`.

**Fix.** Pass an explicit algorithm list to the three-arg `calculateHashes` overload that arrived in the *same* Core release, filtering only the SHA3 family by a `MessageDigest.getInstance` probe. The list is now plugin-owned rather than inherited, so a future Core release cannot silently move the SBOM Output Contract (ADR 0004).

| Build JVM | Before this commit | After | vs. 3.3.0 |
|---|---|---|---|
| Java 8 | task fails | 5 hashes | identical |
| Java 9+ | 8 hashes | 8 hashes | identical |
| FIPS (no MD5) | fails | fails | identical |

Only SHA3 is probed — the rest stay unguarded so a JVM that cannot provide them still fails loudly instead of emitting an SBOM whose missing hashes are indistinguishable from ones the schema never asked for.

**Also in this PR:** `junit-jupiter-engine` was missing from the test runtime classpath (only `junit-jupiter-api` plus Spock's engine), so **no plain JUnit 5 test under `src/test/java` had ever been discovered** — `DependencyUtilsTest` and `EnvironmentUtilsTest` were dormant. Adding the engine was a prerequisite for the new guard to run at all; both dormant classes pass.

**Verification.** `testJava8` 114 tests / 0 failures (all 11 previously-failing cells green), `testJava21` 151 / 0, `spotlessCheck` clean. `HashUtilsTest.probesRealAvailability` asserts the production probe agrees with the JVM running it, so it demands SHA3 absent under `testJava8` and present under `testJava21` — the parity claim is verified on both, not asserted.

Reasoning recorded as ADR 0006; ADR 0005 and `CONTEXT.md` updated.


---

**Rebased onto master** (`688a239`, "feat: allow configuring Test Configuration name patterns").

Two collisions resolved:

1. **`CONTEXT.md`** — master added a **Test Configuration** term and a flagged ambiguity; this stack added two flagged ambiguities (Output Contract conditioned on the build JVM, and *build JVM* vs. Java 8 bytecode target). Both sides kept; the two Output Contract bullets are now adjacent.
2. **ADR number collision** — master took `0005` for `classify-test-configurations-by-name-pattern`. This stack's ADRs renumbered accordingly, with every cross-reference in the ADR bodies, `HashUtils` javadoc, and commit messages updated:
   - `0005-isolate-only-version-branching-from-core-in-the-3x-line` → **`0006`**
   - `0006-declare-the-artifact-hash-algorithm-set-in-the-plugin` → **`0007`**

`SbomBuilder` auto-merged cleanly — master's `isTestConfiguration`/`getTestConfigsPatterns` sit alongside this stack's `hashAlgorithms` field without overlap.

Re-verified after rebase: `spotlessCheck`, `testJava8` and `testJava21` all green.
