### PR TITLE
feat: add opt-in CycloneDX 1.7 (Version.VERSION_17) schema support

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,10 @@ the CycloneDX version supported by the target system.
 | 1.1.x   | CycloneDX v1.1 | XML       |
 | 1.0x    | CycloneDX v1.0 | XML       |
 
+> [!NOTE]
+> `Version.VERSION_17` (CycloneDX 1.7) can be selected opt-in via `schemaVersion`. `Version.VERSION_16`
+> (CycloneDX 1.6) remains the default.
+
 ## Copyright & License
 
 CycloneDX Gradle Plugin is Copyright (c) OWASP Foundation. All Rights Reserved.

--- a/src/main/java/org/cyclonedx/gradle/utils/CyclonedxUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/CyclonedxUtils.java
@@ -64,6 +64,8 @@ public class CyclonedxUtils {
                 return Version.VERSION_15;
             case "1.6":
                 return Version.VERSION_16;
+            case "1.7":
+                return Version.VERSION_17;
             default:
                 return DEFAULT_SCHEMA_VERSION;
         }

--- a/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/PluginConfigurationSpec.groovy
@@ -158,6 +158,49 @@ class PluginConfigurationSpec extends Specification {
         javaVersion = JavaVersion.current()
     }
 
+    def "should use configured schemaVersion for CycloneDX 1.7 (opt-in)"() {
+        given:
+        File testDir = TestUtils.createFromString("""
+            plugins {
+                id 'org.cyclonedx.bom'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+            tasks.withType(org.cyclonedx.gradle.BaseCyclonedxTask) {
+                schemaVersion = org.cyclonedx.Version.VERSION_17
+            }
+            dependencies {
+                implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version:'2.8.11'
+                implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web', version:'1.5.18.RELEASE'
+            }""", "rootProject.name = 'hello-world'")
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments(taskName))
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(":" + taskName).outcome == TaskOutcome.SUCCESS
+        File reportDir = new File(testDir, reportLocation)
+
+        assert reportDir.exists()
+        reportDir.listFiles({ File file -> file.isFile() } as FileFilter).length == 2
+        File jsonBom = new File(reportDir, "bom.json")
+        assert jsonBom.text.contains("\"specVersion\" : \"1.7\"")
+
+        where:
+        taskName             | reportLocation
+        "cyclonedxDirectBom" | "build/reports/cyclonedx-direct"
+        "cyclonedxBom"       | "build/reports/cyclonedx"
+        javaVersion = JavaVersion.current()
+    }
+
     def "should use project name as componentName"() {
         given:
         File testDir = TestUtils.createFromString("""


### PR DESCRIPTION
## Summary

PR 2 of 4 for #884, stacked on #885 (Core 13.0.0 bump). Adds **opt-in** support for `Version.VERSION_17` (CycloneDX 1.7 schema) — Core 13.0.0 added this enum constant and ships the 1.7 JSON/XML schema resources.

- `CyclonedxUtils.schemaVersion(String)` now maps `"1.7"` to `Version.VERSION_17`, consistent with the rest of that switch.
- README documents `Version.VERSION_17` as an opt-in `schemaVersion` selector; `Version.VERSION_16` remains the default.
- New parameterized test cases (mirroring the existing `VERSION_13` case) set `schemaVersion = Version.VERSION_17` for both `cyclonedxDirectBom` and `cyclonedxBom`, assert `TaskOutcome.SUCCESS`, and assert `bom.json` contains `"specVersion" : "1.7"`. Task success here is a real assertion: `CyclonedxUtils.writeJsonBom`/`writeXmlBom` validate against Core's bundled schema and throw on failure.

## Scope

Deliberately shallow — proves 1.7 works end-to-end via the plugin's existing generic construction logic (there's no version-based gate today, so any `Version` the task property is set to already flows through). No 1.7-only field mapping (license `items`/expression-detailed, `Metadata.distributionConstraints`, new `ExternalReference` types) — that's #832's job. Default schema stays 1.6.

## Verification

- `./gradlew spotlessCheck` — clean
- `./gradlew compileJava compileTestJava compileTestGroovy` — zero errors/warnings
- `./gradlew testJava21 --tests "*PluginConfigurationSpec*"` — all 56 cases pass, including both new VERSION_17 cases and every pre-existing case (VERSION_13, 1.6-is-default, etc.)

Part of the #884 stack: #885 (this PR's base) → **this PR** → #stack continues below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebased** onto the updated PR1 branch, which now carries the Java 8 hashing fix (Core 12.1.0 made `BomUtils.calculateHashes` throw on a JVM without SHA3) plus the `junit-jupiter-engine` addition that makes `src/test/java` tests run at all. Verified after rebase: `testJava8` and `testJava21` both green, `spotlessCheck` clean.

Note this PR targets a branch, so the `build` workflow does not run on it — `ci-build.yaml` triggers only on `pull_request: branches: [master]`. Full-matrix verification is via `gh workflow run "Build CI" --ref <branch>` until it retargets `master`.


---

**Rebased onto master** (`688a239`, "feat: allow configuring Test Configuration name patterns").

Two collisions resolved:

1. **`CONTEXT.md`** — master added a **Test Configuration** term and a flagged ambiguity; this stack added two flagged ambiguities (Output Contract conditioned on the build JVM, and *build JVM* vs. Java 8 bytecode target). Both sides kept; the two Output Contract bullets are now adjacent.
2. **ADR number collision** — master took `0005` for `classify-test-configurations-by-name-pattern`. This stack's ADRs renumbered accordingly, with every cross-reference in the ADR bodies, `HashUtils` javadoc, and commit messages updated:
   - `0005-isolate-only-version-branching-from-core-in-the-3x-line` → **`0006`**
   - `0006-declare-the-artifact-hash-algorithm-set-in-the-plugin` → **`0007`**

`SbomBuilder` auto-merged cleanly — master's `isTestConfiguration`/`getTestConfigsPatterns` sit alongside this stack's `hashAlgorithms` field without overlap.

Re-verified after rebase: `spotlessCheck`, `testJava8` and `testJava21` all green.
