### PR TITLE
refactor: isolate Core version-branching behind an internal SchemaVersion type

### DIFF
--- a/docs/adr/0006-isolate-only-version-branching-from-core-in-the-3x-line.md
+++ b/docs/adr/0006-isolate-only-version-branching-from-core-in-the-3x-line.md
@@ -9,10 +9,11 @@ construction behind plugin-owned internal values. We isolated only the places th
 `org.cyclonedx.Version` and the schema-version allow-list behind an internal version type, rather than mirroring
 `OrganizationalEntity`, `LicenseChoice`, and `ExternalReference` as plugin-owned types.
 
-There are three such branches: the manufacturer/manufacture and Tool/ToolInformation thresholds in `SbomBuilder`, and
-the `>= 1.2` extension of the artifact hash algorithm set in `HashUtils` that ADR 0007 moved into the plugin. The third
-arrives with the Core upgrade itself, ahead of the internal version type, so it is written as a direct `Version`
-comparison and folded in when that type lands.
+There are three such branches, all now expressed as `SchemaVersion` predicates: the manufacturer/manufacture and
+Tool/ToolInformation thresholds in `SbomBuilder` (`usesManufacturer`, `usesToolInformation`), and the `>= 1.2`
+extension of the artifact hash algorithm set in `HashUtils` that ADR 0007 moved into the plugin
+(`includesExtendedHashes`). The third arrived with the Core upgrade itself, ahead of this type, and was written as a
+direct `Version` comparison until the type landed.
 
 ## Consequences
 

--- a/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
+++ b/src/main/java/org/cyclonedx/gradle/SbomBuilder.java
@@ -39,6 +39,8 @@ import org.cyclonedx.gradle.model.DependencyComparator;
 import org.cyclonedx.gradle.model.SbomComponent;
 import org.cyclonedx.gradle.model.SbomComponentId;
 import org.cyclonedx.gradle.model.SbomGraph;
+import org.cyclonedx.gradle.model.SchemaVersion;
+import org.cyclonedx.gradle.model.SchemaVersionMapper;
 import org.cyclonedx.gradle.utils.DependencyUtils;
 import org.cyclonedx.gradle.utils.EnvironmentUtils;
 import org.cyclonedx.gradle.utils.ExternalReferencesUtil;
@@ -70,10 +72,12 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
     private final List<Hash.Algorithm> hashAlgorithms;
     private final MavenHelper mavenHelper;
     private final Version version;
+    private final SchemaVersion schemaVersion;
     private final T task;
 
     SbomBuilder(final T task) {
         this.version = task.getSchemaVersion().get();
+        this.schemaVersion = SchemaVersionMapper.from(this.version);
         this.artifactHashes = new HashMap<>();
         this.hashAlgorithms = HashUtils.selectAlgorithms(this.version);
         this.mavenHelper = new MavenHelper(task.getIncludeLicenseText().get());
@@ -125,7 +129,7 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
         if (task.getOrganizationalEntity().isPresent()
                 && !new OrganizationalEntity()
                         .equals(task.getOrganizationalEntity().get())) {
-            if (version.compareTo(Version.VERSION_16) >= 0) {
+            if (schemaVersion.usesManufacturer()) {
                 metadata.setManufacturer(task.getOrganizationalEntity().get());
             } else {
                 metadata.setManufacture(task.getOrganizationalEntity().get());
@@ -135,7 +139,7 @@ class SbomBuilder<T extends BaseCyclonedxTask> {
         final Properties pluginProperties = readPluginProperties();
         if (!pluginProperties.isEmpty()) {
             // if schema version is 1.5 or higher use tools instead of tool
-            if (version.compareTo(Version.VERSION_15) >= 0) {
+            if (schemaVersion.usesToolInformation()) {
                 final Component component = new Component();
                 component.setType(Component.Type.APPLICATION);
                 component.setAuthor(pluginProperties.getProperty("vendor"));

--- a/src/main/java/org/cyclonedx/gradle/model/SchemaVersion.java
+++ b/src/main/java/org/cyclonedx/gradle/model/SchemaVersion.java
@@ -20,29 +20,31 @@ package org.cyclonedx.gradle.model;
 
 /**
  * Plugin-internal, Core-free stand-in for the CycloneDX schema selectors the plugin currently knows about (1.0
- * through 1.7). It exists solely to capture the two structural differences that {@code SbomBuilder} branches on when
- * building {@code Metadata}, so that class does not need to reason about {@code org.cyclonedx.Version} directly for
- * those decisions.
+ * through 1.7). It exists solely to capture the structural differences the plugin branches on when building a
+ * {@code Bom}, so those call sites do not need to reason about {@code org.cyclonedx.Version} directly.
  *
  * <p>This type deliberately does not import anything from {@code org.cyclonedx.*}. See {@link SchemaVersionMapper}
  * for the one-way translation from Core's {@code org.cyclonedx.Version}.
  */
 public enum SchemaVersion {
-    VERSION_10(false, false),
-    VERSION_11(false, false),
-    VERSION_12(false, false),
-    VERSION_13(false, false),
-    VERSION_14(false, false),
-    VERSION_15(true, false),
-    VERSION_16(true, true),
-    VERSION_17(true, true);
+    VERSION_10(false, false, false),
+    VERSION_11(false, false, false),
+    VERSION_12(false, false, true),
+    VERSION_13(false, false, true),
+    VERSION_14(false, false, true),
+    VERSION_15(true, false, true),
+    VERSION_16(true, true, true),
+    VERSION_17(true, true, true);
 
     private final boolean usesToolInformation;
     private final boolean usesManufacturer;
+    private final boolean includesExtendedHashes;
 
-    SchemaVersion(final boolean usesToolInformation, final boolean usesManufacturer) {
+    SchemaVersion(
+            final boolean usesToolInformation, final boolean usesManufacturer, final boolean includesExtendedHashes) {
         this.usesToolInformation = usesToolInformation;
         this.usesManufacturer = usesManufacturer;
+        this.includesExtendedHashes = includesExtendedHashes;
     }
 
     /**
@@ -59,5 +61,13 @@ public enum SchemaVersion {
      */
     public boolean usesManufacturer() {
         return usesManufacturer;
+    }
+
+    /**
+     * @return {@code true} for schema 1.2 and above, where an artifact carries SHA-384 and SHA3-384 hashes in addition
+     *     to the set every schema version carries. Core rejects SHA3-384 below 1.2 via its {@code VersionFilter}.
+     */
+    public boolean includesExtendedHashes() {
+        return includesExtendedHashes;
     }
 }

--- a/src/main/java/org/cyclonedx/gradle/model/SchemaVersion.java
+++ b/src/main/java/org/cyclonedx/gradle/model/SchemaVersion.java
@@ -1,0 +1,63 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.model;
+
+/**
+ * Plugin-internal, Core-free stand-in for the CycloneDX schema selectors the plugin currently knows about (1.0
+ * through 1.7). It exists solely to capture the two structural differences that {@code SbomBuilder} branches on when
+ * building {@code Metadata}, so that class does not need to reason about {@code org.cyclonedx.Version} directly for
+ * those decisions.
+ *
+ * <p>This type deliberately does not import anything from {@code org.cyclonedx.*}. See {@link SchemaVersionMapper}
+ * for the one-way translation from Core's {@code org.cyclonedx.Version}.
+ */
+public enum SchemaVersion {
+    VERSION_10(false, false),
+    VERSION_11(false, false),
+    VERSION_12(false, false),
+    VERSION_13(false, false),
+    VERSION_14(false, false),
+    VERSION_15(true, false),
+    VERSION_16(true, true),
+    VERSION_17(true, true);
+
+    private final boolean usesToolInformation;
+    private final boolean usesManufacturer;
+
+    SchemaVersion(final boolean usesToolInformation, final boolean usesManufacturer) {
+        this.usesToolInformation = usesToolInformation;
+        this.usesManufacturer = usesManufacturer;
+    }
+
+    /**
+     * @return {@code true} for schema 1.5 and above, where CycloneDX metadata tooling is expressed as
+     *     {@code ToolInformation} (a list of {@code Component}s) rather than the legacy {@code Tool}.
+     */
+    public boolean usesToolInformation() {
+        return usesToolInformation;
+    }
+
+    /**
+     * @return {@code true} for schema 1.6 and above, where the metadata author is expressed via
+     *     {@code metadata.manufacturer} rather than the legacy {@code metadata.manufacture}.
+     */
+    public boolean usesManufacturer() {
+        return usesManufacturer;
+    }
+}

--- a/src/main/java/org/cyclonedx/gradle/model/SchemaVersionMapper.java
+++ b/src/main/java/org/cyclonedx/gradle/model/SchemaVersionMapper.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.model;
+
+import org.cyclonedx.Version;
+
+/**
+ * One-way mapper from Core's {@link Version} to the plugin-internal {@link SchemaVersion}. Only the two
+ * version-conditional decision points in {@code SbomBuilder.buildMetadata()} need this translation; every other use
+ * of {@link Version} in the plugin (hash calculation, BOM serialization/validation, the schema-version CLI/DSL
+ * mapping in {@code CyclonedxUtils.schemaVersion(String)}) keeps using the Core type directly and is untouched by
+ * this class.
+ */
+public final class SchemaVersionMapper {
+
+    private SchemaVersionMapper() {}
+
+    /**
+     * Maps a Core {@link Version} to the corresponding {@link SchemaVersion}.
+     *
+     * <p>Comparisons are ordinal, mirroring the {@code Version.compareTo(...)} checks this type replaces, so a
+     * genuinely unknown future {@link Version} constant (newer than {@link Version#VERSION_17}) is never rejected —
+     * it falls back to the newest known schema's thresholds ({@link SchemaVersion#VERSION_17}), staying exactly as
+     * permissive as the raw {@code compareTo} logic it replaces.
+     *
+     * @param coreVersion the Core schema version to translate
+     * @return the corresponding internal {@link SchemaVersion}
+     */
+    public static SchemaVersion from(final Version coreVersion) {
+        if (coreVersion.compareTo(Version.VERSION_17) >= 0) {
+            return SchemaVersion.VERSION_17;
+        } else if (coreVersion.compareTo(Version.VERSION_16) >= 0) {
+            return SchemaVersion.VERSION_16;
+        } else if (coreVersion.compareTo(Version.VERSION_15) >= 0) {
+            return SchemaVersion.VERSION_15;
+        } else if (coreVersion.compareTo(Version.VERSION_14) >= 0) {
+            return SchemaVersion.VERSION_14;
+        } else if (coreVersion.compareTo(Version.VERSION_13) >= 0) {
+            return SchemaVersion.VERSION_13;
+        } else if (coreVersion.compareTo(Version.VERSION_12) >= 0) {
+            return SchemaVersion.VERSION_12;
+        } else if (coreVersion.compareTo(Version.VERSION_11) >= 0) {
+            return SchemaVersion.VERSION_11;
+        } else {
+            return SchemaVersion.VERSION_10;
+        }
+    }
+}

--- a/src/main/java/org/cyclonedx/gradle/utils/HashUtils.java
+++ b/src/main/java/org/cyclonedx/gradle/utils/HashUtils.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 import org.cyclonedx.Version;
+import org.cyclonedx.gradle.model.SchemaVersionMapper;
 import org.cyclonedx.model.Hash;
 
 /**
@@ -33,6 +34,9 @@ import org.cyclonedx.model.Hash;
  *
  * <p>The set is declared here rather than inherited from {@code BomUtils.calculateHashes(File, Version)} so that a
  * cyclonedx-core-java upgrade cannot silently move the SBOM Output Contract. See ADR 0007.
+ *
+ * <p>The schema-dependent part of the set is decided by {@code SchemaVersion} rather than by comparing Core's
+ * {@code Version} directly, per ADR 0006.
  *
  * <p>The SHA3 family is filtered by availability because Java 8 ships no SHA3 provider. Core 12.1.0 replaced the
  * defensive acquisition that used to skip those algorithms with one that throws, which aborts SBOM generation outright
@@ -82,7 +86,7 @@ public class HashUtils {
             final Version schemaVersion, final Predicate<Hash.Algorithm> available) {
 
         final List<Hash.Algorithm> candidates = new ArrayList<>(BASE_ALGORITHMS);
-        if (schemaVersion.getVersion() >= 1.2) {
+        if (SchemaVersionMapper.from(schemaVersion).includesExtendedHashes()) {
             candidates.addAll(EXTENDED_ALGORITHMS);
         }
 

--- a/src/test/java/org/cyclonedx/gradle/model/SchemaVersionMapperTest.java
+++ b/src/test/java/org/cyclonedx/gradle/model/SchemaVersionMapperTest.java
@@ -86,6 +86,18 @@ class SchemaVersionMapperTest {
         }
     }
 
+    @Test
+    void extendedHashesStartAt12() {
+        // SHA-384 and SHA3-384 join the artifact hash set at 1.2, and Core rejects SHA3-384 below that via its
+        // VersionFilter, so this threshold must hold for every constant Core defines.
+        for (final Version coreVersion : Version.values()) {
+            assertEquals(
+                    coreVersion.getVersion() >= 1.2,
+                    SchemaVersionMapper.from(coreVersion).includesExtendedHashes(),
+                    coreVersion.getVersionString());
+        }
+    }
+
     private void assertThresholds(
             final Version coreVersion,
             final SchemaVersion expected,

--- a/src/test/java/org/cyclonedx/gradle/model/SchemaVersionMapperTest.java
+++ b/src/test/java/org/cyclonedx/gradle/model/SchemaVersionMapperTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.cyclonedx.Version;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that {@link SchemaVersionMapper} reproduces exactly what the old inline {@code SbomBuilder} logic
+ * produced for every schema version 1.0 through 1.7:
+ *
+ * <pre>
+ * usesManufacturer      = version.compareTo(Version.VERSION_16) &gt;= 0
+ * usesToolInformation   = version.compareTo(Version.VERSION_15) &gt;= 0
+ * </pre>
+ */
+class SchemaVersionMapperTest {
+
+    @Test
+    void version10DoesNotUseManufacturerOrToolInformation() {
+        assertThresholds(Version.VERSION_10, SchemaVersion.VERSION_10, false, false);
+    }
+
+    @Test
+    void version11DoesNotUseManufacturerOrToolInformation() {
+        assertThresholds(Version.VERSION_11, SchemaVersion.VERSION_11, false, false);
+    }
+
+    @Test
+    void version12DoesNotUseManufacturerOrToolInformation() {
+        assertThresholds(Version.VERSION_12, SchemaVersion.VERSION_12, false, false);
+    }
+
+    @Test
+    void version13DoesNotUseManufacturerOrToolInformation() {
+        assertThresholds(Version.VERSION_13, SchemaVersion.VERSION_13, false, false);
+    }
+
+    @Test
+    void version14DoesNotUseManufacturerOrToolInformation() {
+        assertThresholds(Version.VERSION_14, SchemaVersion.VERSION_14, false, false);
+    }
+
+    @Test
+    void version15UsesToolInformationButNotManufacturer() {
+        assertThresholds(Version.VERSION_15, SchemaVersion.VERSION_15, true, false);
+    }
+
+    @Test
+    void version16UsesManufacturerAndToolInformation() {
+        assertThresholds(Version.VERSION_16, SchemaVersion.VERSION_16, true, true);
+    }
+
+    @Test
+    void version17UsesManufacturerAndToolInformation() {
+        assertThresholds(Version.VERSION_17, SchemaVersion.VERSION_17, true, true);
+    }
+
+    @Test
+    void everyCoreVersionConstantMapsWithoutThrowing() {
+        // Guards against Core adding a new Version constant (e.g. a future 1.8) without this mapper being
+        // revisited: every constant Core 13.0.0 defines must round-trip through the mapper without throwing.
+        for (final Version coreVersion : Version.values()) {
+            final SchemaVersion result = SchemaVersionMapper.from(coreVersion);
+            assertEquals(SchemaVersion.valueOf(coreVersion.name()), result);
+        }
+    }
+
+    private void assertThresholds(
+            final Version coreVersion,
+            final SchemaVersion expected,
+            final boolean usesToolInformation,
+            final boolean usesManufacturer) {
+        final SchemaVersion result = SchemaVersionMapper.from(coreVersion);
+
+        assertEquals(expected, result);
+        assertEquals(usesToolInformation, result.usesToolInformation(), "usesToolInformation");
+        assertEquals(usesManufacturer, result.usesManufacturer(), "usesManufacturer");
+
+        if (usesManufacturer) {
+            assertTrue(result.usesManufacturer());
+        } else {
+            assertFalse(result.usesManufacturer());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

PR 3 of 4 for #884, stacked on #886 (opt-in 1.7 support). Implements the scope decision recorded in [ADR 0005](docs/adr/0005-isolate-only-version-branching-from-core-in-the-3x-line.md): isolate only the plugin's actual `org.cyclonedx.Version`-conditional branching logic behind a small internal, Core-free type — not a wider mirror of `OrganizationalEntity`/`LicenseChoice`/`ExternalReference`/`Component.Type` (those stay Core types end-to-end; full DSL-facing internal model normalization is #883's job).

- New `org.cyclonedx.gradle.model.SchemaVersion` enum (`VERSION_10`…`VERSION_17`, zero Core imports) with `usesToolInformation()` (1.5+) and `usesManufacturer()` (1.6+).
- New `SchemaVersionMapper.from(org.cyclonedx.Version)` — a one-way mapper, never throws/rejects, and an unknown future `Version` falls through to the newest-known behavior (exactly as permissive as the old raw `compareTo` checks).
- `SbomBuilder.buildMetadata()` now computes this once and uses the two query methods instead of inline `version.compareTo(Version.VERSION_16)` / `compareTo(Version.VERSION_15)`. Every other use of the real `Version` (e.g. `BomUtils.calculateHashes`, `CyclonedxUtils.writeJsonBom/writeXmlBom`) is untouched.
- New unit tests covering every `Version` constant 1.0–1.7.

## Why this is safe — pure refactor, verified byte-identical output

This is the highest-risk PR in the stack since it touches production construction logic rather than being purely additive. Verified equivalence directly: generated `bom.json`/`bom.xml` for schema versions 1.4, 1.5, and 1.6 (straddling both thresholds) on this branch vs. the parent commit, normalized to strip the ADR-0004-exempt fields (`serialNumber`, `timestamp`), and diffed — **byte-identical** in both formats at all three versions.

## Verification

- `./gradlew spotlessCheck` — clean
- `./gradlew compileJava compileTestJava compileGroovy` — zero errors; no new NullAway/errorprone findings in the new `model` package (it's inside the `@NullMarked` package NullAway enforces as ERROR)
- `./gradlew testJava21 --tests "*OrganizationalEntityUtilTest*" --tests "*PluginConfigurationSpec*" --tests "*CycloneDxSpec*" --tests "*SbomBuilder*"` plus the new `SchemaVersionMapperTest` — all pass, `OrganizationalEntityUtilTest`'s 1.6 manufacturer/manufacture threshold coverage unchanged

## Note: pre-existing gap found, not fixed here (out of scope)

While verifying the new plain-JUnit5 test, found that `build.gradle.kts` declares `junit-jupiter-api` but never `junit-jupiter-engine`, so plain JUnit5 `@Test` classes under `src/test/java` (including pre-existing `DependencyUtilsTest`/`EnvironmentUtilsTest`, and now this PR's `SchemaVersionMapperTest`) are silently never discovered/executed by `./gradlew testJava*`. Confirmed independently by temporarily adding the missing engine dependency and observing all of them actually run and pass. Filing this as a separate follow-up rather than folding an unrelated build-config fix into this stack.

Part of the #884 stack: #885 → #886 (this PR's base) → **this PR** → PR4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebased**, and extended to absorb the third `Version` branch.

The Core 13 upgrade in PR1 introduced one: the `>= 1.2` extension of the artifact hash algorithm set in `HashUtils`, added by ADR 0006 to keep hashing working on a Java 8 build JVM. It had to ship as a direct `Version` comparison because it lands with the upgrade, ahead of this type. ADR 0005 asked for exactly this case to extend the same internal type rather than introduce a second isolation mechanism, so it is now `SchemaVersion.includesExtendedHashes()`.

All three branches now read as predicates on the internal type: `usesManufacturer()`, `usesToolInformation()`, `includesExtendedHashes()`. Behavior is unchanged — `SchemaVersionMapper` maps every Core constant 1:1, so the predicate reproduces the `>= 1.2` threshold exactly, and `SchemaVersionMapperTest.extendedHashesStartAt12` asserts that across every constant Core defines.

Verified after rebase: `testJava8` and `testJava21` both green, `spotlessCheck` clean.

Note this PR targets a branch, so the `build` workflow does not run on it — `ci-build.yaml` triggers only on `pull_request: branches: [master]`. Full-matrix verification is via `gh workflow run "Build CI" --ref <branch>` until it retargets `master`.


---

**Rebased onto master** (`688a239`, "feat: allow configuring Test Configuration name patterns").

Two collisions resolved:

1. **`CONTEXT.md`** — master added a **Test Configuration** term and a flagged ambiguity; this stack added two flagged ambiguities (Output Contract conditioned on the build JVM, and *build JVM* vs. Java 8 bytecode target). Both sides kept; the two Output Contract bullets are now adjacent.
2. **ADR number collision** — master took `0005` for `classify-test-configurations-by-name-pattern`. This stack's ADRs renumbered accordingly, with every cross-reference in the ADR bodies, `HashUtils` javadoc, and commit messages updated:
   - `0005-isolate-only-version-branching-from-core-in-the-3x-line` → **`0006`**
   - `0006-declare-the-artifact-hash-algorithm-set-in-the-plugin` → **`0007`**

`SbomBuilder` auto-merged cleanly — master's `isTestConfiguration`/`getTestConfigsPatterns` sit alongside this stack's `hashAlgorithms` field without overlap.

Re-verified after rebase: `spotlessCheck`, `testJava8` and `testJava21` all green.
