### PR TITLE
test: add binary-compatibility fixture against published plugin 3.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,30 @@ dependencies {
     errorprone("com.google.errorprone:error_prone_core:2.50.0")
 }
 
+// Builds LegacyConsumerFixture (see legacy-fixture-build/) - a stand-in for a buildSrc/build-logic consumer
+// precompiled against the published cyclonedx-gradle-plugin:3.3.0 (Core 11.0.1) - so BinaryCompatibilitySpec can run
+// that precompiled bytecode against this build's own candidate plugin (Core 13.0.0) and catch binary-incompatible
+// Core upgrades that source-recompiled tests never see. It has to live in its own nested Gradle build, invoked here
+// via `--project-dir` rather than as a source set of this project: this project publishes itself under the exact
+// same GA (`org.cyclonedx:cyclonedx-gradle-plugin`) that the fixture needs to compile against at version 3.3.0, and
+// Gradle 9.x unconditionally substitutes a project for any module dependency whose group:name matches a project in
+// the same build - regardless of requested version, and not overridable via `resolutionStrategy` - which would
+// silently make the fixture compile against this project's own (candidate) classes instead of the real old release.
+val legacyFixtureBuildDir = "legacy-fixture-build"
+val legacyFixtureJarFile = layout.projectDirectory.file("$legacyFixtureBuildDir/build/libs/legacy-consumer-fixture.jar")
+
+val legacyFixtureJar = tasks.register<Exec>("legacyFixtureJar") {
+    description = "Builds the LegacyConsumerFixture jar in an isolated nested Gradle build (see legacy-fixture-build/)"
+    workingDir = rootDir
+    val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+    val gradlewName = if (isWindows) "gradlew.bat" else "./gradlew"
+    commandLine(gradlewName, "--project-dir", legacyFixtureBuildDir, "jar")
+    inputs.dir("$legacyFixtureBuildDir/src")
+    inputs.file("$legacyFixtureBuildDir/build.gradle.kts")
+    inputs.file("$legacyFixtureBuildDir/settings.gradle.kts")
+    outputs.file(legacyFixtureJarFile)
+}
+
 val localTestRepository = layout.buildDirectory.dir("local-repo")
 
 listOf(8, 11, 17, 21, 25).forEach { version ->
@@ -68,9 +92,16 @@ listOf(8, 11, 17, 21, 25).forEach { version ->
         testLogging {
             events("passed", "skipped", "failed")
         }
-        dependsOn("publishAllPublicationsToLocalTestRepository")
+        dependsOn("publishAllPublicationsToLocalTestRepository", legacyFixtureJar)
+        // The fixture jar is only referenced by absolute path via a system property below, which Gradle's
+        // up-to-date check treats as an opaque string - it would not notice the jar's *content* changing (e.g. a
+        // LegacyConsumerFixture.java edit that doesn't also touch BinaryCompatibilitySpec.groovy) and could report a
+        // stale PASSED result. Declaring it as an explicit input makes its content part of this task's up-to-date
+        // check.
+        inputs.files(legacyFixtureJar).withPropertyName("legacyFixtureJar").withPathSensitivity(PathSensitivity.NONE)
         systemProperty("localRepoPath", project.relativePath(localTestRepository.get()))
         systemProperty("pluginVersion", project.version.toString())
+        systemProperty("legacyFixtureJarPath", legacyFixtureJarFile.asFile.absolutePath)
     }
 }
 

--- a/legacy-fixture-build/build.gradle.kts
+++ b/legacy-fixture-build/build.gradle.kts
@@ -1,0 +1,64 @@
+// A deliberately separate Gradle build (its own settings.gradle.kts, invoked via `--project-dir` from the main
+// build's `legacyFixtureJar` task; see build.gradle.kts) rather than a source set of the main project.
+//
+// Why it can't be a source set: the main project publishes itself as `org.cyclonedx:cyclonedx-gradle-plugin`, the
+// exact GA of the artifact this fixture must compile against (the previously published 3.3.0 release). Gradle 9.x
+// unconditionally substitutes a project for any module dependency whose group:name matches a project in the *same
+// build*, regardless of requested version and regardless of any `resolutionStrategy.dependencySubstitution` rule -
+// this is "deprecated" starting Gradle 10 but is current, non-overridable behavior on the Gradle 9.x line this repo
+// targets. So `compileOnly("org.cyclonedx:cyclonedx-gradle-plugin:3.3.0")` declared inside the main build would
+// always resolve back to the main build's own (candidate, Core 13.0.0) classes, silently defeating the whole point.
+// A separate build has no such self-reference and resolves the real published 3.3.0 artifact.
+plugins {
+    id("java")
+    id("com.diffplug.spotless") version "8.8.0"
+}
+
+repositories {
+    mavenCentral()
+    gradlePluginPortal()
+}
+
+dependencies {
+    // compileOnly: this fixture must never bundle the 3.3.0 plugin or Core 11.0.1 classes it compiles against -
+    // only its own compiled class(es) get jarred (see the `jar` task below) and placed on a test's runtime
+    // classpath, where those types must resolve against the *candidate* plugin instead.
+    compileOnly("org.cyclonedx:cyclonedx-gradle-plugin:3.3.0")
+    compileOnly(gradleApi())
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    options.release = 8
+}
+
+tasks.jar {
+    archiveFileName.set("legacy-consumer-fixture.jar")
+}
+
+// Mirrors the root build's spotless { java { ... } } block: this nested build has its own build.gradle.kts, so the
+// root project's spotless configuration does not reach in here. Kept in sync by hand if the root config changes.
+spotless {
+    java {
+        palantirJavaFormat("2.86.0")
+        formatAnnotations()
+        licenseHeader("/*\n" +
+            " * This file is part of CycloneDX Gradle Plugin.\n" +
+            " *\n" +
+            " * Licensed under the Apache License, Version 2.0 (the \"License\");\n" +
+            " * you may not use this file except in compliance with the License.\n" +
+            " * You may obtain a copy of the License at\n" +
+            " *\n" +
+            " *     http://www.apache.org/licenses/LICENSE-2.0\n" +
+            " *\n" +
+            " * Unless required by applicable law or agreed to in writing, software\n" +
+            " * distributed under the License is distributed on an \"AS IS\" BASIS,\n" +
+            " * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n" +
+            " * See the License for the specific language governing permissions and\n" +
+            " * limitations under the License.\n" +
+            " *\n" +
+            " * SPDX-License-Identifier: Apache-2.0\n" +
+            " * Copyright (c) OWASP Foundation. All Rights Reserved.\n" +
+            " */")
+    }
+}

--- a/legacy-fixture-build/settings.gradle.kts
+++ b/legacy-fixture-build/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "legacy-fixture-build"

--- a/legacy-fixture-build/src/main/java/org/cyclonedx/gradle/fixture/LegacyConsumerFixture.java
+++ b/legacy-fixture-build/src/main/java/org/cyclonedx/gradle/fixture/LegacyConsumerFixture.java
@@ -1,0 +1,92 @@
+/*
+ * This file is part of CycloneDX Gradle Plugin.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright (c) OWASP Foundation. All Rights Reserved.
+ */
+package org.cyclonedx.gradle.fixture;
+
+import java.util.Collections;
+import org.cyclonedx.Version;
+import org.cyclonedx.gradle.CyclonedxDirectTask;
+import org.cyclonedx.model.Component;
+import org.cyclonedx.model.ExternalReference;
+import org.cyclonedx.model.License;
+import org.cyclonedx.model.LicenseChoice;
+import org.cyclonedx.model.OrganizationalEntity;
+import org.gradle.api.Task;
+
+/**
+ * A stand-in for a real plugin consumer's precompiled build logic (e.g. a {@code buildSrc} convention plugin or an
+ * included {@code build-logic} build).
+ *
+ * <p>This class lives in {@code legacy-fixture-build}, a Gradle build kept deliberately separate from the rest of
+ * this repository, and is compiled against the previously published {@code org.cyclonedx:cyclonedx-gradle-plugin
+ * :3.3.0} artifact, which transitively pulls {@code org.cyclonedx:cyclonedx-core-java:11.0.1}. (It can't be a source
+ * set of the main build: that build publishes itself under this exact same GA, and Gradle always substitutes a
+ * project for a module dependency with matching group:name within the same build - see the {@code legacyFixtureJar}
+ * task in the root {@code build.gradle.kts} for the full explanation.) Its resulting {@code .class} file is packaged
+ * by that nested build's {@code jar} task into a small jar containing only this fixture, and is never rebuilt
+ * afterwards.
+ *
+ * <p>At test time that jar is placed on a build's {@code buildscript} classpath alongside the <em>candidate</em>
+ * version of this plugin (built from this repository's current source, on the newer Core release under test) but
+ * without the 3.3.0 jar or Core 11.0.1 anywhere on the runtime classpath. When {@link #configure(Task)} runs, the JVM
+ * resolves every type it references &mdash; {@code org.cyclonedx.gradle.CyclonedxDirectTask}, {@code
+ * org.cyclonedx.Version}, {@code org.cyclonedx.model.*} &mdash; against whatever classes are actually present at
+ * runtime, i.e. the candidate's. If the candidate's Core dependency removed or incompatibly changed any method this
+ * class calls, that resolution fails with a real {@code NoSuchMethodError}/{@code NoSuchFieldError}, exactly as it
+ * would for a real precompiled consumer. See {@code BinaryCompatibilitySpec}.
+ */
+public final class LegacyConsumerFixture {
+
+    public static final String ORGANIZATION_NAME = "Legacy Consumer Org";
+
+    public static final String LICENSE_NAME = "Legacy Consumer License";
+
+    public static final String EXTERNAL_REFERENCE_URL = "https://legacy-consumer.example.com";
+
+    private LegacyConsumerFixture() {}
+
+    /**
+     * Exercises all five Core-backed {@code BaseCyclonedxTask} properties using Core 11.0.1 types, the same way a
+     * precompiled consumer configuring {@code cyclonedxDirectBom} directly would.
+     *
+     * @param rawTask the live {@code cyclonedxDirectBom} task instance, passed as the Gradle {@link Task} supertype
+     *     so the caller does not need this fixture's compile-time-only {@code CyclonedxDirectTask} type on its own
+     *     classpath
+     */
+    public static void configure(final Task rawTask) {
+        final CyclonedxDirectTask task = (CyclonedxDirectTask) rawTask;
+
+        task.getSchemaVersion().set(Version.VERSION_16);
+        task.getProjectType().set(Component.Type.LIBRARY);
+
+        final OrganizationalEntity organizationalEntity = new OrganizationalEntity();
+        organizationalEntity.setName(ORGANIZATION_NAME);
+        task.getOrganizationalEntity().set(organizationalEntity);
+
+        final License license = new License();
+        license.setName(LICENSE_NAME);
+        final LicenseChoice licenseChoice = new LicenseChoice();
+        licenseChoice.addLicense(license);
+        task.getLicenseChoice().set(licenseChoice);
+
+        final ExternalReference externalReference = new ExternalReference();
+        externalReference.setType(ExternalReference.Type.WEBSITE);
+        externalReference.setUrl(EXTERNAL_REFERENCE_URL);
+        task.getExternalReferences().set(Collections.singletonList(externalReference));
+    }
+}

--- a/src/test/groovy/org/cyclonedx/gradle/BinaryCompatibilitySpec.groovy
+++ b/src/test/groovy/org/cyclonedx/gradle/BinaryCompatibilitySpec.groovy
@@ -1,0 +1,85 @@
+package org.cyclonedx.gradle
+
+import groovy.json.JsonSlurper
+import org.gradle.api.JavaVersion
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.IgnoreIf
+import spock.lang.Specification
+
+/**
+ * Regression coverage for issue #884: upgrading {@code cyclonedx-core-java} must not break consumers who configure
+ * this plugin from precompiled bytecode (a {@code buildSrc} convention plugin or an included {@code build-logic}
+ * build), compiled once against an older plugin release and then loaded, unchanged, against a newer one.
+ *
+ * <p>Ordinary specs can't catch this: they always drive the plugin through a build script Gradle recompiles from
+ * source, which recompiles against whatever Core version is currently on the classpath and so can never observe a
+ * removed/incompatibly-changed method.
+ *
+ * <p>This spec instead loads {@code LegacyConsumerFixture} - compiled ahead of time (see the {@code legacy-fixture-
+ * build} nested Gradle build and its {@code legacyFixtureJar} wiring in the root {@code build.gradle.kts}) against
+ * the published {@code cyclonedx-gradle-plugin:3.3.0}, which
+ * transitively depends on {@code cyclonedx-core-java:11.0.1} - onto the buildscript classpath of a project that
+ * applies the *candidate* plugin (this build's own code, resolved as a real published artifact from the local test
+ * repository, on whatever Core version is currently under test). Neither the 3.3.0 jar nor Core 11.0.1 is anywhere on
+ * that runtime classpath, so every type {@code LegacyConsumerFixture} references resolves against the candidate's
+ * classes. If a method or field it calls was removed or changed incompatibly, the build fails with a real
+ * {@code NoSuchMethodError}/{@code NoSuchFieldError} instead of quietly succeeding.
+ */
+@IgnoreIf({ !JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_17) })
+class BinaryCompatibilitySpec extends Specification {
+
+    def "precompiled consumer bytecode from plugin 3.3.0 runs against the candidate plugin's Core version"() {
+        given: "the candidate plugin resolved as a real published artifact, plus a fixture jar compiled against 3.3.0"
+        def localRepoUrl = new File(System.getProperty("localRepoPath")).toURI().toString()
+        def pluginVersion = System.getProperty("pluginVersion")
+        def legacyFixtureJarPath = System.getProperty("legacyFixtureJarPath").replace("\\", "/")
+
+        File testDir = TestUtils.createFromString("""
+            buildscript {
+                dependencies {
+                    classpath files('${legacyFixtureJarPath}')
+                }
+            }
+            plugins {
+                id 'org.cyclonedx.bom' version '${pluginVersion}'
+                id 'java'
+            }
+            repositories {
+                mavenCentral()
+            }
+            group = 'com.example'
+            version = '1.0.0'
+
+            // Stands in for a buildSrc/build-logic convention plugin precompiled against plugin 3.3.0: it directly
+            // casts the live task to CyclonedxDirectTask and calls the same five Core-backed properties a real
+            // consumer would, using Core 11.0.1 types.
+            tasks.named('cyclonedxDirectBom') { t ->
+                org.cyclonedx.gradle.fixture.LegacyConsumerFixture.configure(t)
+            }
+            """, """
+            pluginManagement {
+                repositories {
+                    maven { url '${localRepoUrl}' }
+                    gradlePluginPortal()
+                }
+            }
+            rootProject.name = 'binary-compatibility'
+        """)
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testDir)
+            .withArguments(TestUtils.arguments("cyclonedxDirectBom"))
+            .build()
+
+        then:
+        result.task(":cyclonedxDirectBom").outcome == TaskOutcome.SUCCESS
+
+        and: "the BOM reflects values the 3.3.0-compiled fixture set - proving the old calls actually took effect"
+        def bom = new JsonSlurper().parse(new File(testDir, "build/reports/cyclonedx-direct/bom.json"))
+        bom.metadata.manufacturer.name == "Legacy Consumer Org"
+        bom.metadata.licenses*.license*.name == ["Legacy Consumer License"]
+        bom.metadata.component.externalReferences*.url.contains("https://legacy-consumer.example.com")
+    }
+}


### PR DESCRIPTION
## Summary

PR 4 of 4 for #884, stacked on #885 (Core 13.0.0 bump). Adds durable binary-compatibility regression coverage: since this plugin exposes Core types directly on its public API (`api("org.cyclonedx:cyclonedx-core-java:...")`, five task properties typed with Core classes), a real consumer configuring the plugin from **precompiled** code (a `buildSrc` convention plugin or an included `build-logic` build) compiled once against an older release could hit a runtime `NoSuchMethodError` on a Core upgrade — a break ordinary source-recompiled tests structurally cannot observe, since Gradle always recompiles build scripts fresh against whatever's currently on the classpath.

## Mechanism

- **`legacy-fixture-build/`** — a deliberately *separate* nested Gradle build (own `settings.gradle.kts`/`build.gradle.kts`) containing `LegacyConsumerFixture.java`, compiled `compileOnly` against the real published `org.cyclonedx:cyclonedx-gradle-plugin:3.3.0` (transitively Core 11.0.1). Its `configure(Task)` static method casts to `CyclonedxDirectTask` and exercises all five core-backed properties using Core 11.0.1 types.
  - Has to be a separate nested build rather than a source set of the main project: this project publishes itself under the exact GA (`org.cyclonedx:cyclonedx-gradle-plugin`) the fixture needs at version 3.3.0, and Gradle 9.x unconditionally substitutes a project for any module dependency with matching group:name within the *same* build — a same-build source set would silently compile against the candidate's own classes instead of the real old release.
- Root `build.gradle.kts` adds a `legacyFixtureJar` task (`Exec`, invokes the nested build's `jar` task) wired as a proper task input (not just a system-property side channel — a caching-staleness bug here was found and fixed during review) into each `testJava$version` task.
- **`BinaryCompatibilitySpec.groovy`** resolves the *candidate* plugin as a real published artifact (same `localRepoPath`/`pluginVersion` mechanism other specs use), puts the fixture jar on a test build's `buildscript` classpath, calls `LegacyConsumerFixture.configure(t)` on the live `cyclonedxDirectBom` task, and asserts both task success and that the generated BOM reflects the exact values the 3.3.0-compiled fixture set — proving the old bytecode's calls actually took effect against the new Core classes, not just "didn't crash."

## Verification

- Deliberately broke the spec's assertion to confirm it actually fails (not vacuously green), then reverted.
- `./gradlew testJava21 --tests "*BinaryCompatibilitySpec*"` — passes, stable across repeated runs.
- Found and fixed a real caching bug: the fixture jar wasn't declared as a task **input**, only referenced via an absolute-path system property, so editing the fixture and rebuilding its jar left `testJava*` reporting stale `UP-TO-DATE` results. Fixed with a proper `inputs.files(...)` declaration; verified the fix actually detects changes.
- Added a `spotless` block to the nested build so `LegacyConsumerFixture.java`'s license header/formatting is self-enforced (the root project's spotless config can't reach into a separate nested build).
- Full `./gradlew testJava21` — all tests pass, confirming the `testJava$version` task changes didn't disturb other specs.

Part of the #884 stack: #885 (this PR's base) → **this PR** (independent of #886/#887).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Rebased** onto the updated PR1 branch, which now carries the Java 8 hashing fix (Core 12.1.0 made `BomUtils.calculateHashes` throw on a JVM without SHA3) plus the `junit-jupiter-engine` addition that makes `src/test/java` tests run at all. Verified after rebase: `testJava8` and `testJava21` both green, `spotlessCheck` clean.

Note this PR targets a branch, so the `build` workflow does not run on it — `ci-build.yaml` triggers only on `pull_request: branches: [master]`. Full-matrix verification is via `gh workflow run "Build CI" --ref <branch>` until it retargets `master`.


---

**Rebased onto master** (`688a239`, "feat: allow configuring Test Configuration name patterns").

Two collisions resolved:

1. **`CONTEXT.md`** — master added a **Test Configuration** term and a flagged ambiguity; this stack added two flagged ambiguities (Output Contract conditioned on the build JVM, and *build JVM* vs. Java 8 bytecode target). Both sides kept; the two Output Contract bullets are now adjacent.
2. **ADR number collision** — master took `0005` for `classify-test-configurations-by-name-pattern`. This stack's ADRs renumbered accordingly, with every cross-reference in the ADR bodies, `HashUtils` javadoc, and commit messages updated:
   - `0005-isolate-only-version-branching-from-core-in-the-3x-line` → **`0006`**
   - `0006-declare-the-artifact-hash-algorithm-set-in-the-plugin` → **`0007`**

`SbomBuilder` auto-merged cleanly — master's `isTestConfiguration`/`getTestConfigsPatterns` sit alongside this stack's `hashAlgorithms` field without overlap.

Re-verified after rebase: `spotlessCheck`, `testJava8` and `testJava21` all green.
